### PR TITLE
Fix CachingQuerySet.count to respect no_cache

### DIFF
--- a/caching/base.py
+++ b/caching/base.py
@@ -191,7 +191,7 @@ class CachingQuerySet(models.query.QuerySet):
         timeout = getattr(settings, 'CACHE_COUNT_TIMEOUT', None)
         super_count = super(CachingQuerySet, self).count
         query_string = 'count:%s' % self.query_key()
-        if timeout is None:
+        if self.timeout == NO_CACHE or timeout is None:
             return super_count()
         else:
             return cached_with(self, super_count, query_string, timeout)

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -163,6 +163,12 @@ class CachingTestCase(ExtraAppTestCase):
         Addon.objects.count()
         eq_(cached_mock.call_count, 0)
 
+    @mock.patch('caching.base.cached')
+    def test_count_nocache(self, cached_mock):
+        settings.CACHE_COUNT_TIMEOUT = 60
+        Addon.objects.no_cache().count()
+        eq_(cached_mock.call_count, 0)
+
     def test_queryset_flush_list(self):
         """Check that we're making a flush list for the queryset."""
         q = Addon.objects.all()


### PR DESCRIPTION
Adds a check to CachingQuerySet.count that sees if the queryset was created with no_cache, and ignores caching if that is the case.
