### PR TITLE
Multi-DB support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 docs/_build
 *.py[co]
+*egg-info

--- a/caching/base.py
+++ b/caching/base.py
@@ -33,7 +33,7 @@ class CachingManager(models.Manager):
     use_for_related_fields = True
 
     def get_query_set(self):
-        return CachingQuerySet(self.model)
+        return CachingQuerySet(self.model, using=self._db)
 
     def contribute_to_class(self, cls, name):
         signals.post_save.connect(self.post_save, sender=cls)

--- a/caching/invalidation.py
+++ b/caching/invalidation.py
@@ -74,7 +74,7 @@ class Invalidator(object):
         flush, flush_keys = self.find_flush_lists(keys)
 
         if flush:
-            cache.set_many(dict((k, None) for k in flush), 5)
+            cache.delete_many(flush)
         if flush_keys:
             self.clear_flush_lists(flush_keys)
 

--- a/examples/cache-machine/settings.py
+++ b/examples/cache-machine/settings.py
@@ -11,11 +11,16 @@ DATABASES = {
     'default': {
         'NAME': 'test.db',
         'ENGINE': 'django.db.backends.sqlite3',
-    }
+    },
+    'slave': {
+        'NAME': 'test_slave.db',
+        'ENGINE': 'django.db.backends.sqlite3',
+        }
 }
 
 INSTALLED_APPS = (
     'django_nose',
+    'tests.testapp',
 )
 
 SECRET_KEY = 'ok'

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,6 @@ mock
 django-nose
 django==1.4
 python-memcached
--e git://github.com/jbalogh/test-utils.git#egg=test-utils
 fabric
 jinja2
 redis

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -446,18 +446,21 @@ class CachingTestCase(TestCase):
 
     def test_multidb_cache(self):
         """ Test where master and slave DB result in two different cache keys """
-
         assert Addon.objects.get(id=1).from_cache is False
         assert Addon.objects.get(id=1).from_cache is True
 
         from_slave = Addon.objects.using('slave').get(id=1)
-        if getattr(settings, 'FETCH_BY_ID', False):
-            # FETCH_BY_ID is not currently compatible with multiple DBs.
-            assert from_slave.from_cache is False
-            assert from_slave._state.db == 'default'
+        assert from_slave.from_cache is False
+        assert from_slave._state.db == 'slave'
+
+    def test_multidb_fetch_by_id(self):
+        """ Test where master and slave DB result in two different cache keys with FETCH_BY_ID"""
+        with self.settings(FETCH_BY_ID=True):
+            assert Addon.objects.get(id=1).from_cache is False
+            assert Addon.objects.get(id=1).from_cache is True
+
             from_slave = Addon.objects.using('slave').get(id=1)
-            assert from_slave.from_cache is True
-            assert from_slave._state.db == 'default'
-        else:
             assert from_slave.from_cache is False
             assert from_slave._state.db == 'slave'
+
+

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -67,6 +67,10 @@ class CachingTestCase(TestCase):
         a = [x for x in Addon.objects.all() if x.id == 1][0]
         assert a.from_cache is False
 
+        assert Addon.objects.get(id=1).from_cache is True
+        a = [x for x in Addon.objects.all() if x.id == 1][0]
+        assert a.from_cache is True
+
     def test_invalidation_cross_locale(self):
         assert Addon.objects.get(id=1).from_cache is False
         a = [x for x in Addon.objects.all() if x.id == 1][0]
@@ -84,9 +88,6 @@ class CachingTestCase(TestCase):
         assert a.from_cache is True
 
         a.save()
-        assert Addon.objects.get(id=1).from_cache is False
-        a = [x for x in Addon.objects.all() if x.id == 1][0]
-        assert a.from_cache is False
 
         translation.activate(old_locale)
         assert Addon.objects.get(id=1).from_cache is False

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -1,20 +1,21 @@
 # -*- coding: utf-8 -*-
 from django.conf import settings
 from django.core.cache import cache
+from django.test import TestCase
 from django.utils import translation, encoding
 
 import jinja2
 import mock
 from nose.tools import eq_
 
-from test_utils import ExtraAppTestCase
 import caching.base as caching
 from caching import invalidation
 
 from testapp.models import Addon, User
 
 
-class CachingTestCase(ExtraAppTestCase):
+class CachingTestCase(TestCase):
+    multi_db = True
     fixtures = ['testapp/test_cache.json']
     extra_apps = ['tests.testapp']
 
@@ -438,3 +439,21 @@ class CachingTestCase(ExtraAppTestCase):
         if not getattr(settings, 'CACHE_MACHINE_USE_REDIS', False):
             cache_mock.return_value.values.return_value = [None, [1]]
             eq_(caching.invalidator.get_flush_lists(None), set([1]))
+
+    def test_multidb_cache(self):
+        """ Test where master and slave DB result in two different cache keys """
+
+        assert Addon.objects.get(id=1).from_cache is False
+        assert Addon.objects.get(id=1).from_cache is True
+
+        from_slave = Addon.objects.using('slave').get(id=1)
+        if getattr(settings, 'FETCH_BY_ID', False):
+            # FETCH_BY_ID is not currently compatible with multiple DBs.
+            assert from_slave.from_cache is False
+            assert from_slave._state.db == 'default'
+            from_slave = Addon.objects.using('slave').get(id=1)
+            assert from_slave.from_cache is True
+            assert from_slave._state.db == 'default'
+        else:
+            assert from_slave.from_cache is False
+            assert from_slave._state.db == 'slave'

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -88,6 +88,9 @@ class CachingTestCase(TestCase):
         assert a.from_cache is True
 
         a.save()
+        assert Addon.objects.get(id=1).from_cache is False
+        a = [x for x in Addon.objects.all() if x.id == 1][0]
+        assert a.from_cache is False
 
         translation.activate(old_locale)
         assert Addon.objects.get(id=1).from_cache is False


### PR DESCRIPTION
cache-machine did not respect multiple databases as intended by https://github.com/jbalogh/django-cache-machine/commit/b0f49d5ac8419cc7db1d38e74e64a400e5977625 and the tests partially hid this.  I was able to extend the tests to cover multiple databases (and removed the test-utils dependency) and was then able to fix the behavior.