### PR TITLE
Fixes #14

### DIFF
--- a/caching/base.py
+++ b/caching/base.py
@@ -200,7 +200,10 @@ class CachingQuerySet(models.query.QuerySet):
 
     def count(self):
         super_count = super(CachingQuerySet, self).count
-        query_string = 'count:%s' % self.query_key()
+        try:
+            query_string = 'count:%s' % self.query_key()
+        except query.EmptyResultSet:
+            return super_count()
         if self.timeout == NO_CACHE or TIMEOUT is None:
             return super_count()
         else:

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -199,6 +199,11 @@ class CachingTestCase(TestCase):
         Addon.objects.no_cache().count()
         eq_(cached_mock.call_count, 0)
 
+    @mock.patch('caching.base.cache')
+    def test_count_cache_empty(self, cache_mock):
+        q = Addon.objects.filter(val__in=[])
+        count = q.count()
+
     def test_queryset_flush_list(self):
         """Check that we're making a flush list for the queryset."""
         q = Addon.objects.all()


### PR DESCRIPTION
This may be a bug that should be fixed in Django, but I haven't dug into as_sql() enough to understand exactly why it's raising an EmptyQuerySet exception in this case. However, the fix for this specific issue is simple enough -- catch that exception and execute the query directly.

We might be able to just return 0 and save the query in this case, but it seems safer to just execute it.