### PR TITLE
Add in support for GenericForeignKey fields.

### DIFF
--- a/caching/base.py
+++ b/caching/base.py
@@ -250,12 +250,13 @@ class CachingMixin(object):
         keys = [fk.rel.to._cache_key(val, self._state.db) for fk, val in fks.items()
                 if val is not None and hasattr(fk.rel.to, '_cache_key')]
 
-        generics = [getattr(self, f.name) for f in self._meta.virtual_fields
+        generics = [f for f in self._meta.virtual_fields
                     if isinstance(f, generic.GenericForeignKey) and
+                    getattr(self, f.ct_field) and
                     hasattr(getattr(self, f.ct_field).model_class(), '_cache_key')]
         if generics:
-            keys = keys + [getattr(self, f.ct_field).model_class()._cache_key(model.pk, self._state.db)
-                           for model in generics]
+            keys = keys + [getattr(self, f.ct_field).model_class()._cache_key(getattr(self, f.fk_field), self._state.db)
+                           for f in generics]
 
         return (self.cache_key,) + tuple(keys)
 

--- a/examples/cache_machine/settings.py
+++ b/examples/cache_machine/settings.py
@@ -19,6 +19,7 @@ DATABASES = {
 }
 
 INSTALLED_APPS = (
+    'django.contrib.contenttypes',
     'django_nose',
     'tests.testapp',
 )

--- a/tests/testapp/models.py
+++ b/tests/testapp/models.py
@@ -36,4 +36,8 @@ class Comment(CachingMixin, models.Model):
     object_id = models.PositiveIntegerField()
     object = generic.GenericForeignKey('object_type', 'object_id')
 
+    object2_type = models.ForeignKey(ContentType, null=True, related_name='+')
+    object2_id = models.PositiveIntegerField(null=True)
+    object2 = generic.GenericForeignKey('object2_type', 'object2_id')
+
     objects = CachingManager()

--- a/tests/testapp/models.py
+++ b/tests/testapp/models.py
@@ -1,3 +1,5 @@
+from django.contrib.contenttypes import generic
+from django.contrib.contenttypes.models import ContentType
 from django.db import models
 
 import mock
@@ -27,3 +29,11 @@ class Addon(CachingMixin, models.Model):
         """This is a docstring for calls()"""
         call_counter()
         return arg, call_counter.call_count
+
+
+class Comment(CachingMixin, models.Model):
+    object_type = models.ForeignKey(ContentType)
+    object_id = models.PositiveIntegerField()
+    object = generic.GenericForeignKey('object_type', 'object_id')
+
+    objects = CachingManager()


### PR DESCRIPTION
GenericForeignKey weren't being included in a model's cache keys, but they should have all the same cache invalidation implications as normal ForeignKey fields, so this commit adds logic to be aware of them.
