### PR TITLE
django 1.6 removes `dup_select_related`

### DIFF
--- a/caching/base.py
+++ b/caching/base.py
@@ -195,7 +195,7 @@ class CachingQuerySet(models.query.QuerySet):
         if hasattr(others, 'no_cache'):
             others = others.no_cache()
         if self.query.select_related:
-            others.dup_select_related(self)
+            others.query.select_related = self.query.select_related
         return others
 
     def count(self):


### PR DESCRIPTION
`dup_select_related` was removed in 
https://github.com/django/django/commit/389892aae595b86c4be28c43e3312d76a68a0173 - replacing it with equivalent behavior here.
