### PR TITLE
A few documentation fixes

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -29,12 +29,12 @@ With Django 1.3 or higher, you should use the ``CACHES`` setting::
                 'server-1:11211',
                 'server-2:11211',
             ],
-            'PREFIX': 'weee:',
+            'KEY_PREFIX': 'weee:',
         },
     }
 
 Note that we have to specify the class, not the module, for the ``BACKEND``
-property, and that the ``PREFIX`` is optional. The ``LOCATION`` may be a
+property, and that the ``KEY_PREFIX`` is optional. The ``LOCATION`` may be a
 string, instead of a list, if you only have one server.
 
 If you require the default cache backend to be a different type of
@@ -53,7 +53,7 @@ options simply define a separate ``cache_machine`` entry for the
                 'server-1:11211',
                 'server-2:11211',
             ],
-            'PREFIX': 'weee:',
+            'KEY_PREFIX': 'weee:',
         },
     }
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -121,7 +121,7 @@ Here's what a minimal cached model looks like::
 
     from django.db import models
 
-    from caching.base imoprt CachingManager, CachingMixin
+    from caching.base import CachingManager, CachingMixin
 
     class Zomg(CachingMixin, models.Model):
         val = models.IntegerField()


### PR DESCRIPTION
The misspelling of `import` is ultimately harmless, although it does look a tad careless.

The incorrect citation of Django 1.3+'s [KEY_PREFIX](https://docs.djangoproject.com/en/1.3/ref/settings/#key-prefix) (which remains [unchanged](https://docs.djangoproject.com/en/1.6/ref/settings/#key-prefix) in 1.6) is super, super dangerous.

I've not verified the instructions for sub-1.3 versions, and since 1.4 is now the oldest supported version of Django anyway, it's probably not a particularly good idea to endorse using such old versions.