### PR TITLE
Remove crate io and update Django versions in travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ install:
 script:
   - fab test
 env:
-  - DJANGO=1.3.3
-  - DJANGO=1.4.1
-  - DJANGO=1.5
-  - DJANGO=1.6
+  - DJANGO=1.3.7
+  - DJANGO=1.4.10
+  - DJANGO=1.5.5
+  - DJANGO=1.6.2


### PR DESCRIPTION
simple.crate.io doesn't have all the old Django releases and seems deprecated among the community anyway - see pydanny/cookiecutter-djangopackage#23. 

This PR removes crate.io and updates Django versions so the travis build can (hopefully) pass.
