### PR TITLE
fixup: `version_info` of python 2.6 is a tuple

### DIFF
--- a/fabfile.py
+++ b/fabfile.py
@@ -40,7 +40,7 @@ except Exception:
     print 'WARNING: Skipping redis tests.'
 
 def test():
-    if sys.version_info.major == 2 and sys.version_info.minor < 7:
+    if sys.version_info[0] == 2 and sys.version_info[1] < 7:
         import django
         if django.VERSION[1] >= 7:
             print("Skipping becuase Django >= 1.7 doesn't work with Python < 2.7")


### PR DESCRIPTION
Sorry, d017dd810 didn't fixed Travis build. This is the fix.

https://travis-ci.org/remohammadi/django-cache-machine/builds/30178694

Can you please release a new version in near future? Referring to the git repository in pip requirements file slows down the processes of deployment and testing.
