### PR TITLE
Fix parse_qsl is not defined

### DIFF
--- a/caching/invalidation.py
+++ b/caching/invalidation.py
@@ -3,6 +3,7 @@ import functools
 import hashlib
 import logging
 import socket
+import urlparse
 
 from django.conf import settings
 from django.core.cache import cache as default_cache, get_cache
@@ -197,7 +198,7 @@ def parse_backend_uri(backend_uri):
     host = rest[2:]
     qpos = rest.find('?')
     if qpos != -1:
-        params = dict(parse_qsl(rest[qpos+1:]))
+        params = dict(urlparse.parse_qsl(rest[qpos+1:]))
         host = rest[2:qpos]
     else:
         params = {}


### PR DESCRIPTION
Using the most recent build from github, I get this error :

File "/src/django-cache-machine/caching/invalidation.py", line 213, in get_redis_backend
    server, params = parse_backend_uri(settings.REDIS_BACKEND)
  File "/src/django-cache-machine/caching/invalidation.py", line 200, in parse_backend_uri
    params = dict(parse_qsl(rest[qpos+1:]))
NameError: global name 'parse_qsl' is not defined

This commit fixes the issue.
