### PR TITLE
Test against packaged Django 1.7.x

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,4 +14,4 @@ env:
   - DJANGO_SPEC="Django>=1.4,<1.5"
   - DJANGO_SPEC="Django>=1.5,<1.6"
   - DJANGO_SPEC="Django>=1.6,<1.7"
-  - DJANGO_SPEC="https://www.djangoproject.com/download/1.7c1/tarball/"
+  - DJANGO_SPEC="Django>=1.7,<1.8"


### PR DESCRIPTION
Travis builds will use subsequent bug fixes versions, too.
