### PR TITLE
Switch from get_cache to caches

### DIFF
--- a/caching/invalidation.py
+++ b/caching/invalidation.py
@@ -4,12 +4,13 @@ import hashlib
 import logging
 import socket
 
+import django
 from django.conf import settings
 from django.core.cache import cache as default_cache
-from django.core.cache import caches
 from django.core.cache.backends.base import InvalidCacheBackendError
 from django.utils import encoding, translation
 from django.utils.six.moves.urllib.parse import parse_qsl
+print 'hi'
 
 try:
     import redis as redislib
@@ -18,7 +19,12 @@ except ImportError:
 
 # Look for an own cache first before falling back to the default cache
 try:
-    cache = caches['cache_machine']
+    if django.VERSION[:2] >= (1, 8):
+        from django.core.cache import caches
+        cache = caches['cache_machine']
+    else:
+        from django.core.cache import get_cache
+        cache = get_cache('cache_machine')
 except (InvalidCacheBackendError, ValueError):
     cache = default_cache
 

--- a/caching/invalidation.py
+++ b/caching/invalidation.py
@@ -6,7 +6,7 @@ import socket
 
 from django.conf import settings
 from django.core.cache import cache as default_cache
-from django.core.cache import get_cache
+from django.core.cache import caches
 from django.core.cache.backends.base import InvalidCacheBackendError
 from django.utils import encoding, translation
 from django.utils.six.moves.urllib.parse import parse_qsl
@@ -18,7 +18,7 @@ except ImportError:
 
 # Look for an own cache first before falling back to the default cache
 try:
-    cache = get_cache('cache_machine')
+    cache = caches['cache_machine']
 except (InvalidCacheBackendError, ValueError):
     cache = default_cache
 

--- a/caching/invalidation.py
+++ b/caching/invalidation.py
@@ -10,7 +10,6 @@ from django.core.cache import cache as default_cache
 from django.core.cache.backends.base import InvalidCacheBackendError
 from django.utils import encoding, translation
 from django.utils.six.moves.urllib.parse import parse_qsl
-print 'hi'
 
 try:
     import redis as redislib
@@ -19,7 +18,7 @@ except ImportError:
 
 # Look for an own cache first before falling back to the default cache
 try:
-    if django.VERSION[:2] >= (1, 8):
+    if django.VERSION[:2] >= (1, 7):
         from django.core.cache import caches
         cache = caches['cache_machine']
     else:


### PR DESCRIPTION
get_cache is deprecated and will be removed in Django 1.9