### PR TITLE
get tests running with Django 1.8; remove references to CacheClass

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,3 +16,10 @@ env:
   - DJANGO_SPEC="Django>=1.6,<1.7"
   - DJANGO_SPEC="Django>=1.7,<1.8"
   - DJANGO_SPEC="Django>=1.8,<1.9"
+
+matrix:
+  exclude:
+    - python: "2.6"
+      env: DJANGO_SPEC="Django>=1.7,<1.8"
+    - python: "2.6"
+      env: DJANGO_SPEC="Django>=1.8,<1.9"

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,3 +15,4 @@ env:
   - DJANGO_SPEC="Django>=1.5,<1.6"
   - DJANGO_SPEC="Django>=1.6,<1.7"
   - DJANGO_SPEC="Django>=1.7,<1.8"
+  - DJANGO_SPEC="Django>=1.8,<1.9"

--- a/caching/backends/locmem.py
+++ b/caching/backends/locmem.py
@@ -37,10 +37,5 @@ class InfinityMixin(object):
         return super(InfinityMixin, self).set(key, value, timeout, version)
 
 
-class CacheClass(InfinityMixin, locmem.CacheClass):
+class LocMemCache(InfinityMixin, locmem.LocMemCache):
     pass
-
-
-if django.VERSION[:2] >= (1, 3):
-    class LocMemCache(InfinityMixin, locmem.LocMemCache):
-        pass

--- a/caching/backends/memcached.py
+++ b/caching/backends/memcached.py
@@ -14,15 +14,8 @@ class InfinityMixin(object):
         return super(InfinityMixin, self).set(key, value, timeout, version)
 
 
-if django.VERSION[:2] >= (1, 3):
-    class MemcachedCache(InfinityMixin, memcached.MemcachedCache):
-        pass
+class MemcachedCache(InfinityMixin, memcached.MemcachedCache):
+    pass
 
-    class PyLibMCCache(InfinityMixin, memcached.PyLibMCCache):
-        pass
-
-    class CacheClass(MemcachedCache):
-        pass
-else:
-    class CacheClass(InfinityMixin, memcached.CacheClass):
-        pass
+class PyLibMCCache(InfinityMixin, memcached.PyLibMCCache):
+    pass

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -8,6 +8,9 @@ Cache Machine provides automatic caching and invalidation for Django models
 through the ORM.  The code is hosted on
 `github <http://github.com/jbalogh/django-cache-machine>`_.
 
+For an overview of new features and backwards-incompatible changes which may
+affect you, please see the :ref:`release-notes`.
+
 Settings
 --------
 

--- a/docs/releases.rst
+++ b/docs/releases.rst
@@ -1,0 +1,21 @@
+.. _release-notes:
+
+Release Notes
+==================
+
+v0.8.1 (release date TBD)
+--------------------------------------
+
+This release is primarily aimed at adding support for more recent versions of
+Django and catching up on recent contributions.
+
+- Allow test suite to run under Django 1.7 and Django 1.8
+
+Backwards Incompatible Changes
+________________________________
+
+- Dropped support for the old style ``caching.backends.memcached.CacheClass`` and
+  ``caching.backends.locmem.CacheClass`` classes. Support for this naming
+  has been deprecated since Django 1.3. You will need to switch your project
+  to use ``MemcachedCache``, ``PyLibMCCache``, or ``LocMemCache`` in place of
+  ``CacheClass``.

--- a/examples/cache_machine/locmem_settings.py
+++ b/examples/cache_machine/locmem_settings.py
@@ -2,6 +2,6 @@ from settings import *
 
 CACHES = {
     'default': {
-        'BACKEND': 'caching.backends.locmem.CacheClass',
+        'BACKEND': 'caching.backends.locmem.LocMemCache',
     },
 }


### PR DESCRIPTION
The code contains references to CacheClass which has been deprecated since Django 1.3 and removed in Django 1.8. This change removes those references along with the conditionals for unsupported (older than 1.3) Django versions.