### PR TITLE
Python 3 support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .coverage
+.tox
 docs/_build
 *.py[co]
 *.egg-info

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ python:
   - "3.4"
 install:
   - pip install -e .
-  - pip install -r requirements.txt "$DJANGO_SPEC"
+  - pip install -r requirements/py`echo $TRAVIS_PYTHON_VERSION|cut -d'.' -f1`.txt "$DJANGO_SPEC"
   - pip install coveralls
 script:
   - python run_tests.py

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,8 @@ services:
 python:
   - "2.6"
   - "2.7"
+  - "3.3"
+  - "3.4"
 install:
   - pip install -e .
   - pip install -r requirements.txt "$DJANGO_SPEC"
@@ -26,3 +28,7 @@ matrix:
       env: DJANGO_SPEC="Django>=1.7,<1.8"
     - python: "2.6"
       env: DJANGO_SPEC="Django>=1.8,<1.9"
+    - python: "3.3"
+      env: DJANGO_SPEC="Django>=1.4,<1.5"
+    - python: "3.4"
+      env: DJANGO_SPEC="Django>=1.4,<1.5"

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,9 @@ language: python
 services:
   - memcached
   - redis-server
+# Use Travis' build matrix and exclude functions rather than running tox
+# directly so that we can run the builds in parallel and get coverage reports
+# for each Python/Django version combo
 python:
   - "2.6"
   - "2.7"

--- a/.travis.yml
+++ b/.travis.yml
@@ -33,3 +33,5 @@ matrix:
       env: DJANGO_SPEC="Django>=1.4,<1.5"
     - python: "3.4"
       env: DJANGO_SPEC="Django>=1.4,<1.5"
+# Adding sudo: False tells Travis to use their container-based infrastructure, which is somewhat faster.
+sudo: False

--- a/README.rst
+++ b/README.rst
@@ -40,5 +40,5 @@ Get it from `github <http://github.com/django-cache-machine/django-cache-machine
 
     git clone git://github.com/django-cache-machine/django-cache-machine.git
     cd django-cache-machine
-    pip install -r requirements/py2.txt  # or py3.txt for Python 3
+    pip install -r requirements/py3.txt  # or py2.txt for Python 2
     python run_tests.py

--- a/README.rst
+++ b/README.rst
@@ -43,5 +43,5 @@ Get it from `github <http://github.com/django-cache-machine/django-cache-machine
 
     git clone git://github.com/django-cache-machine/django-cache-machine.git
     cd django-cache-machine
-    pip install -r requirements.txt
+    pip install -r requirements/py2.txt  # or py3.txt for Python 3
     python run_tests.py

--- a/caching/__init__.py
+++ b/caching/__init__.py
@@ -1,2 +1,4 @@
+from __future__ import unicode_literals
+
 VERSION = ('0', '8', '1')
 __version__ = '.'.join(VERSION)

--- a/caching/backends/locmem.py
+++ b/caching/backends/locmem.py
@@ -1,3 +1,5 @@
+from __future__ import unicode_literals
+
 import django
 from django.core.cache.backends import locmem
 

--- a/caching/backends/memcached.py
+++ b/caching/backends/memcached.py
@@ -1,3 +1,5 @@
+from __future__ import unicode_literals
+
 from django.core.cache.backends import memcached
 
 from caching.compat import DEFAULT_TIMEOUT

--- a/caching/base.py
+++ b/caching/base.py
@@ -1,3 +1,5 @@
+from __future__ import unicode_literals
+
 import functools
 import logging
 
@@ -8,7 +10,7 @@ from django.db.models import signals
 from django.db.models.sql import query, EmptyResultSet
 from django.utils import encoding
 
-from .compat import DEFAULT_TIMEOUT, u
+from .compat import DEFAULT_TIMEOUT
 from .invalidation import invalidator, flush_key, make_key, byid, cache
 
 
@@ -89,7 +91,7 @@ class CacheMachine(object):
         master), throwing a Django ValueError in the process. Django prevents
         cross DB model saving among related objects.
         """
-        query_db_string = u('qs:%s::db:%s') % (self.query_string, self.db)
+        query_db_string = 'qs:%s::db:%s' % (self.query_string, self.db)
         return make_key(query_db_string, with_locale=False)
 
     def __iter__(self):
@@ -302,10 +304,10 @@ def cached_with(obj, f, f_key, timeout=DEFAULT_TIMEOUT):
         obj_key = (obj.query_key() if hasattr(obj, 'query_key')
                    else obj.cache_key)
     except (AttributeError, EmptyResultSet):
-        log.warning(u('%r cannot be cached.') % encoding.smart_text(obj))
+        log.warning('%r cannot be cached.' % encoding.smart_text(obj))
         return f()
 
-    key = u('%s:%s') % tuple(map(encoding.smart_text, (f_key, obj_key)))
+    key = '%s:%s' % tuple(map(encoding.smart_text, (f_key, obj_key)))
     # Put the key generated in cached() into this object's flush list.
     invalidator.add_to_flush_list(
         {obj.flush_key(): [_function_cache_key(key)]})

--- a/caching/base.py
+++ b/caching/base.py
@@ -89,7 +89,7 @@ class CacheMachine(object):
         master), throwing a Django ValueError in the process. Django prevents
         cross DB model saving among related objects.
         """
-        query_db_string = u('qs:{0}::db:{1}').format(self.query_string, self.db)
+        query_db_string = u('qs:%s::db:%s') % (self.query_string, self.db)
         return make_key(query_db_string, with_locale=False)
 
     def __iter__(self):

--- a/caching/base.py
+++ b/caching/base.py
@@ -302,10 +302,10 @@ def cached_with(obj, f, f_key, timeout=DEFAULT_TIMEOUT):
         obj_key = (obj.query_key() if hasattr(obj, 'query_key')
                    else obj.cache_key)
     except (AttributeError, EmptyResultSet):
-        log.warning(u('%r cannot be cached.' % encoding.smart_str(obj)))
+        log.warning(u('%r cannot be cached.') % encoding.smart_text(obj))
         return f()
 
-    key = '%s:%s' % tuple(map(encoding.smart_str, (f_key, obj_key)))
+    key = u('%s:%s') % tuple(map(encoding.smart_text, (f_key, obj_key)))
     # Put the key generated in cached() into this object's flush list.
     invalidator.add_to_flush_list(
         {obj.flush_key(): [_function_cache_key(key)]})

--- a/caching/base.py
+++ b/caching/base.py
@@ -8,7 +8,7 @@ from django.db.models import signals
 from django.db.models.sql import query, EmptyResultSet
 from django.utils import encoding
 
-from .compat import DEFAULT_TIMEOUT
+from .compat import DEFAULT_TIMEOUT, u
 from .invalidation import invalidator, flush_key, make_key, byid, cache
 
 
@@ -89,7 +89,7 @@ class CacheMachine(object):
         master), throwing a Django ValueError in the process. Django prevents
         cross DB model saving among related objects.
         """
-        query_db_string = u'qs:%s::db:%s' % (self.query_string, self.db)
+        query_db_string = u('qs:{0}::db:{1}').format(self.query_string, self.db)
         return make_key(query_db_string, with_locale=False)
 
     def __iter__(self):
@@ -113,7 +113,7 @@ class CacheMachine(object):
         to_cache = []
         try:
             while True:
-                obj = iterator.next()
+                obj = next(iterator)
                 obj.from_cache = False
                 to_cache.append(obj)
                 yield obj
@@ -169,14 +169,14 @@ class CachingQuerySet(models.query.QuerySet):
         """
         # Include columns from extra since they could be used in the query's
         # order_by.
-        vals = self.values_list('pk', *self.query.extra.keys())
+        vals = self.values_list('pk', *list(self.query.extra.keys()))
         pks = [val[0] for val in vals]
         keys = dict((byid(self.model._cache_key(pk, self.db)), pk) for pk in pks)
-        cached = dict((k, v) for k, v in cache.get_many(keys).items()
+        cached = dict((k, v) for k, v in list(cache.get_many(keys).items())
                       if v is not None)
 
         # Pick up the objects we missed.
-        missed = [pk for key, pk in keys.items() if key not in cached]
+        missed = [pk for key, pk in list(keys.items()) if key not in cached]
         if missed:
             others = self.fetch_missed(missed)
             # Put the fetched objects back in cache.
@@ -186,7 +186,7 @@ class CachingQuerySet(models.query.QuerySet):
             new = {}
 
         # Use pks to return the objects in the correct order.
-        objects = dict((o.pk, o) for o in cached.values() + new.values())
+        objects = dict((o.pk, o) for o in list(cached.values()) + list(new.values()))
         for pk in pks:
             yield objects[pk]
 
@@ -246,14 +246,14 @@ class CachingMixin(object):
         For the Addon class, with a pk of 2, we get "o:addons.addon:2".
         """
         key_parts = ('o', cls._meta, pk, db)
-        return ':'.join(map(encoding.smart_unicode, key_parts))
+        return ':'.join(map(encoding.smart_text, key_parts))
 
     def _cache_keys(self):
         """Return the cache key for self plus all related foreign keys."""
         fks = dict((f, getattr(self, f.attname)) for f in self._meta.fields
                    if isinstance(f, models.ForeignKey))
 
-        keys = [fk.rel.to._cache_key(val, self._state.db) for fk, val in fks.items()
+        keys = [fk.rel.to._cache_key(val, self._state.db) for fk, val in list(fks.items())
                 if val is not None and hasattr(fk.rel.to, '_cache_key')]
         return (self.cache_key,) + tuple(keys)
 
@@ -270,7 +270,7 @@ class CachingRawQuerySet(models.query.RawQuerySet):
         if self.timeout == NO_CACHE:
             iterator = iterator()
             while True:
-                yield iterator.next()
+                yield next(iterator)
         else:
             sql = self.raw_query % tuple(self.params)
             for obj in CacheMachine(sql, iterator, timeout=self.timeout):
@@ -302,7 +302,7 @@ def cached_with(obj, f, f_key, timeout=DEFAULT_TIMEOUT):
         obj_key = (obj.query_key() if hasattr(obj, 'query_key')
                    else obj.cache_key)
     except (AttributeError, EmptyResultSet):
-        log.warning(u'%r cannot be cached.' % encoding.smart_str(obj))
+        log.warning(u('%r cannot be cached.' % encoding.smart_str(obj)))
         return f()
 
     key = '%s:%s' % tuple(map(encoding.smart_str, (f_key, obj_key)))
@@ -352,11 +352,11 @@ class MethodWrapper(object):
 
     def __call__(self, *args, **kwargs):
         k = lambda o: o.cache_key if hasattr(o, 'cache_key') else o
-        arg_keys = map(k, args)
-        kwarg_keys = [(key, k(val)) for key, val in kwargs.items()]
+        arg_keys = list(map(k, args))
+        kwarg_keys = [(key, k(val)) for key, val in list(kwargs.items())]
         key_parts = ('m', self.obj.cache_key, self.func.__name__,
                      arg_keys, kwarg_keys)
-        key = ':'.join(map(encoding.smart_unicode, key_parts))
+        key = ':'.join(map(encoding.smart_text, key_parts))
         if key not in self.cache:
             f = functools.partial(self.func, self.obj, *args, **kwargs)
             self.cache[key] = cached_with(self.obj, f, key)

--- a/caching/compat.py
+++ b/caching/compat.py
@@ -1,6 +1,5 @@
 from __future__ import unicode_literals
 
-import sys
 import django
 
 __all__ = ['DEFAULT_TIMEOUT', 'FOREVER']

--- a/caching/compat.py
+++ b/caching/compat.py
@@ -1,7 +1,7 @@
 import sys
 import django
 
-__all__ = ['DEFAULT_TIMEOUT', 'FOREVER', 'u', 'basestring_']
+__all__ = ['DEFAULT_TIMEOUT', 'FOREVER', 'u']
 
 
 if django.VERSION[:2] >= (1, 6):
@@ -17,8 +17,6 @@ if sys.version_info < (3,):
 
     def u(x):
         return codecs.unicode_escape_decode(x)[0]
-    basestring_ = basestring  # flake8: noqa
 else:
     def u(x):
         return x
-    basestring_ = str

--- a/caching/compat.py
+++ b/caching/compat.py
@@ -1,7 +1,9 @@
+from __future__ import unicode_literals
+
 import sys
 import django
 
-__all__ = ['DEFAULT_TIMEOUT', 'FOREVER', 'u']
+__all__ = ['DEFAULT_TIMEOUT', 'FOREVER']
 
 
 if django.VERSION[:2] >= (1, 6):
@@ -11,12 +13,3 @@ if django.VERSION[:2] >= (1, 6):
 else:
     DEFAULT_TIMEOUT = None
     FOREVER = 0
-
-if sys.version_info < (3,):
-    import codecs
-
-    def u(x):
-        return codecs.unicode_escape_decode(x)[0]
-else:
-    def u(x):
-        return x

--- a/caching/compat.py
+++ b/caching/compat.py
@@ -1,6 +1,7 @@
+import sys
 import django
 
-__all__ = ['DEFAULT_TIMEOUT', 'FOREVER']
+__all__ = ['DEFAULT_TIMEOUT', 'FOREVER', 'u', 'basestring_']
 
 
 if django.VERSION[:2] >= (1, 6):
@@ -10,3 +11,13 @@ if django.VERSION[:2] >= (1, 6):
 else:
     DEFAULT_TIMEOUT = None
     FOREVER = 0
+
+if sys.version_info < (3,):
+    import codecs
+    def u(x):
+        return codecs.unicode_escape_decode(x)[0]
+    basestring_ = basestring
+else:
+    def u(x):
+        return x
+    basestring_ = str

--- a/caching/compat.py
+++ b/caching/compat.py
@@ -14,9 +14,10 @@ else:
 
 if sys.version_info < (3,):
     import codecs
+
     def u(x):
         return codecs.unicode_escape_decode(x)[0]
-    basestring_ = basestring
+    basestring_ = basestring  # flake8: noqa
 else:
     def u(x):
         return x

--- a/caching/ext.py
+++ b/caching/ext.py
@@ -1,3 +1,5 @@
+from __future__ import unicode_literals
+
 from django.conf import settings
 from django.utils import encoding
 

--- a/caching/ext.py
+++ b/caching/ext.py
@@ -33,7 +33,7 @@ class FragmentCacheExtension(Extension):
         # we only listen to ``'cache'`` so this will be a name token with
         # `cache` as value.  We get the line number so that we can give
         # that line number to the nodes we create by hand.
-        lineno = parser.stream.next().lineno
+        lineno = next(parser.stream).lineno
 
         # Use the filename + line number and first object for the cache key.
         name = '%s+%s' % (self.name, lineno)

--- a/caching/invalidation.py
+++ b/caching/invalidation.py
@@ -39,7 +39,7 @@ log = logging.getLogger('caching.invalidation')
 
 def make_key(k, with_locale=True):
     """Generate the full key for ``k``, with a prefix."""
-    key = '%s:%s' % (CACHE_PREFIX, encoding.smart_text(k))
+    key = encoding.smart_text('%s:%s' % (CACHE_PREFIX, k))
     if with_locale:
         key += encoding.smart_text(translation.get_language())
     # memcached keys must be < 250 bytes and w/o whitespace, but it's nice
@@ -172,6 +172,8 @@ class RedisInvalidator(Invalidator):
         pipe = redis.pipeline(transaction=False)
         for key, list_ in list(mapping.items()):
             for query_key in list_:
+                # Redis happily accepts unicode, but returns byte strings,
+                # so manually encode and decode the keys on the flush list here
                 pipe.sadd(self.safe_key(key), query_key.encode('utf-8'))
         pipe.execute()
 

--- a/caching/invalidation.py
+++ b/caching/invalidation.py
@@ -8,10 +8,8 @@ import django
 from django.conf import settings
 from django.core.cache import cache as default_cache
 from django.core.cache.backends.base import InvalidCacheBackendError
-from django.utils import encoding, translation
+from django.utils import encoding, translation, six
 from django.utils.six.moves.urllib.parse import parse_qsl
-
-from .compat import basestring_
 
 try:
     import redis as redislib
@@ -49,12 +47,12 @@ def make_key(k, with_locale=True):
 
 def flush_key(obj):
     """We put flush lists in the flush: namespace."""
-    key = obj if isinstance(obj, basestring_) else obj.cache_key
+    key = obj if isinstance(obj, six.string_types) else obj.cache_key
     return FLUSH + make_key(key, with_locale=False)
 
 
 def byid(obj):
-    key = obj if isinstance(obj, basestring_) else obj.cache_key
+    key = obj if isinstance(obj, six.string_types) else obj.cache_key
     return make_key('byid:' + key)
 
 

--- a/caching/invalidation.py
+++ b/caching/invalidation.py
@@ -1,3 +1,5 @@
+from __future__ import unicode_literals
+
 import collections
 import functools
 import hashlib

--- a/caching/invalidation.py
+++ b/caching/invalidation.py
@@ -37,12 +37,12 @@ log = logging.getLogger('caching.invalidation')
 
 def make_key(k, with_locale=True):
     """Generate the full key for ``k``, with a prefix."""
-    key = encoding.smart_text('%s:%s' % (CACHE_PREFIX, k))
+    key = encoding.smart_bytes('%s:%s' % (CACHE_PREFIX, k))
     if with_locale:
-        key += encoding.smart_text(translation.get_language())
+        key += encoding.smart_bytes(translation.get_language())
     # memcached keys must be < 250 bytes and w/o whitespace, but it's nice
     # to see the keys when using locmem.
-    return hashlib.md5(encoding.smart_bytes(key)).hexdigest()
+    return hashlib.md5(key).hexdigest()
 
 
 def flush_key(obj):

--- a/examples/cache_machine/custom_backend.py
+++ b/examples/cache_machine/custom_backend.py
@@ -1,4 +1,4 @@
-from settings import *  # flake8: noqa
+from .settings import *  # flake8: noqa
 
 CACHES = {
     'default': {

--- a/examples/cache_machine/custom_backend.py
+++ b/examples/cache_machine/custom_backend.py
@@ -5,7 +5,7 @@ CACHES = {
         'BACKEND': 'django.core.cache.backends.locmem.LocMemCache',
     },
     'cache_machine': {
-        'BACKEND': 'caching.backends.memcached.PyLibMCCache',
+        'BACKEND': 'caching.backends.memcached.MemcachedCache',
         'LOCATION': 'localhost:11211',
     },
 }

--- a/examples/cache_machine/custom_backend.py
+++ b/examples/cache_machine/custom_backend.py
@@ -5,7 +5,7 @@ CACHES = {
         'BACKEND': 'django.core.cache.backends.locmem.LocMemCache',
     },
     'cache_machine': {
-        'BACKEND': 'caching.backends.memcached.MemcachedCache',
+        'BACKEND': 'caching.backends.memcached.PyLibMCCache',
         'LOCATION': 'localhost:11211',
     },
 }

--- a/examples/cache_machine/locmem_settings.py
+++ b/examples/cache_machine/locmem_settings.py
@@ -1,4 +1,4 @@
-from settings import *  # flake8: noqa
+from .settings import *  # flake8: noqa
 
 CACHES = {
     'default': {

--- a/examples/cache_machine/memcache_byid.py
+++ b/examples/cache_machine/memcache_byid.py
@@ -1,3 +1,3 @@
-from settings import *  # flake8: noqa
+from .settings import *  # flake8: noqa
 
 FETCH_BY_ID = True

--- a/examples/cache_machine/redis_byid.py
+++ b/examples/cache_machine/redis_byid.py
@@ -1,3 +1,3 @@
-from redis_settings import *  # flake8: noqa
+from .redis_settings import *  # flake8: noqa
 
 FETCH_BY_ID = True

--- a/examples/cache_machine/redis_settings.py
+++ b/examples/cache_machine/redis_settings.py
@@ -1,4 +1,4 @@
-from settings import *  # flake8: noqa
+from .settings import *  # flake8: noqa
 
 CACHE_MACHINE_USE_REDIS = True
 REDIS_BACKEND = 'redis://'

--- a/examples/cache_machine/settings.py
+++ b/examples/cache_machine/settings.py
@@ -1,6 +1,6 @@
 CACHES = {
     'default': {
-        'BACKEND': 'caching.backends.memcached.PyLibMCCache',
+        'BACKEND': 'caching.backends.memcached.MemcachedCache',
         'LOCATION': 'localhost:11211',
     },
 }

--- a/examples/cache_machine/settings.py
+++ b/examples/cache_machine/settings.py
@@ -15,7 +15,7 @@ DATABASES = {
     'slave': {
         'NAME': 'test_slave.db',
         'ENGINE': 'django.db.backends.sqlite3',
-        }
+    },
 }
 
 INSTALLED_APPS = (

--- a/examples/cache_machine/settings.py
+++ b/examples/cache_machine/settings.py
@@ -1,6 +1,6 @@
 CACHES = {
     'default': {
-        'BACKEND': 'caching.backends.memcached.MemcachedCache',
+        'BACKEND': 'caching.backends.memcached.PyLibMCCache',
         'LOCATION': 'localhost:11211',
     },
 }

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,7 @@ sphinx
 mock
 django-nose
 python-memcached
+pylibmc
 jinja2
 redis
 flake8

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -2,8 +2,6 @@
 sphinx
 mock
 django-nose
-python-memcached
-pylibmc
 jinja2
 redis
 flake8

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,7 +1,6 @@
 # These are the reqs to build docs and run tests.
 --no-binary :all:  # workaround for https://bitbucket.org/ned/coveragepy/issue/382/pip-install-coverage-uses-slower-pytracer
 sphinx
-mock==1.0.1
 django-nose
 jinja2
 redis

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,7 +1,7 @@
 # These are the reqs to build docs and run tests.
 --no-binary :all:  # workaround for https://bitbucket.org/ned/coveragepy/issue/382/pip-install-coverage-uses-slower-pytracer
 sphinx
-mock
+mock==1.0.1
 django-nose
 jinja2
 redis

--- a/requirements/py2.txt
+++ b/requirements/py2.txt
@@ -1,0 +1,2 @@
+-r base.txt
+python-memcached

--- a/requirements/py2.txt
+++ b/requirements/py2.txt
@@ -1,2 +1,3 @@
 -r base.txt
 python-memcached
+mock==1.0.1

--- a/requirements/py3.txt
+++ b/requirements/py3.txt
@@ -1,0 +1,2 @@
+-r base.txt
+python3-memcached

--- a/run_tests.py
+++ b/run_tests.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 """
 Creating standalone Django apps is a PITA because you're not in a project, so
 you don't have a settings.py file.  I can never remember to define

--- a/run_tests.py
+++ b/run_tests.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python
 """
 Creating standalone Django apps is a PITA because you're not in a project, so
 you don't have a settings.py file.  I can never remember to define

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,11 @@
 from setuptools import setup
 
+import sys
 import caching
 
+extra = {}
+if sys.version_info >= (3,):
+    extra['use_2to3'] = True
 
 setup(
     name='django-cache-machine',
@@ -27,5 +31,6 @@ setup(
         'Operating System :: OS Independent',
         'Programming Language :: Python',
         'Topic :: Software Development :: Libraries :: Python Modules',
-    ]
+    ],
+    **extra
 )

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,12 @@ setup(
         'Intended Audience :: Developers',
         'License :: OSI Approved :: BSD License',
         'Operating System :: OS Independent',
-        'Programming Language :: Python',
+        'Programming Language :: Python :: 2',
+        'Programming Language :: Python :: 2.6',
+        'Programming Language :: Python :: 2.7',
+        'Programming Language :: Python :: 3',
+        'Programming Language :: Python :: 3.3',
+        'Programming Language :: Python :: 3.4',
         'Topic :: Software Development :: Libraries :: Python Modules',
     ]
 )

--- a/setup.py
+++ b/setup.py
@@ -1,11 +1,7 @@
 from setuptools import setup
 
-import sys
 import caching
 
-extra = {}
-if sys.version_info >= (3,):
-    extra['use_2to3'] = True
 
 setup(
     name='django-cache-machine',
@@ -31,6 +27,5 @@ setup(
         'Operating System :: OS Independent',
         'Programming Language :: Python',
         'Topic :: Software Development :: Libraries :: Python Modules',
-    ],
-    **extra
+    ]
 )

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -1,19 +1,22 @@
 from __future__ import unicode_literals
 
 import django
+import jinja2
+
 from django.conf import settings
 from django.test import TestCase
-from django.utils import translation, encoding
+from django.utils import translation, encoding, six
 
-import jinja2
-import mock
+if six.PY3:
+    from unittest import mock
+else:
+    import mock
 from nose.tools import eq_
 
 from caching import base, invalidation
+from .testapp.models import Addon, User
 
 cache = invalidation.cache
-
-from .testapp.models import Addon, User
 
 if django.get_version().startswith('1.3'):
     class settings_patch(object):

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -1,3 +1,5 @@
+from __future__ import unicode_literals
+
 import django
 from django.conf import settings
 from django.test import TestCase
@@ -8,7 +10,6 @@ import mock
 from nose.tools import eq_
 
 from caching import base, invalidation
-from caching.compat import u
 
 cache = invalidation.cache
 
@@ -342,10 +343,10 @@ class CachingTestCase(TestCase):
         eq_(base.cached_with([], f, 'key'), 1)
 
     def test_cached_with_unicode(self):
-        ustr = encoding.smart_bytes(u('\\u05ea\\u05d9\\u05d0\\u05d5\\u05e8 '
-                                      '\\u05d0\\u05d5\\u05e1\\u05e3'))
+        ustr = encoding.smart_bytes('\\u05ea\\u05d9\\u05d0\\u05d5\\u05e8 '
+                                    '\\u05d0\\u05d5\\u05e1\\u05e3')
         obj = mock.Mock()
-        obj.query_key.return_value = u('xxx')
+        obj.query_key.return_value = 'xxx'
         obj.flush_key.return_value = 'key'
         f = lambda: 1
         eq_(base.cached_with(obj, f, 'adf:%s' % ustr), 1)
@@ -429,7 +430,7 @@ class CachingTestCase(TestCase):
         eq_(kwargs, {'timeout': 12})
 
     def test_unicode_key(self):
-        list(User.objects.filter(name=u('\\xfcmla\\xfct')))
+        list(User.objects.filter(name='\\xfcmla\\xfct'))
 
     def test_empty_in(self):
         # Raised an exception before fixing #2.

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -342,8 +342,8 @@ class CachingTestCase(TestCase):
         eq_(base.cached_with([], f, 'key'), 1)
 
     def test_cached_with_unicode(self):
-        ustr = u('\\u05ea\\u05d9\\u05d0\\u05d5\\u05e8 \\u05d0\\u05d5\\u05e1\\u05e3')
-        ustr = ':'.join(map(encoding.smart_str, [ustr]))
+        ustr = encoding.smart_bytes(u('\\u05ea\\u05d9\\u05d0\\u05d5\\u05e8 '
+                                      '\\u05d0\\u05d5\\u05e1\\u05e3'))
         obj = mock.Mock()
         obj.query_key.return_value = u('xxx')
         obj.flush_key.return_value = 'key'

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -465,7 +465,7 @@ class CachingTestCase(TestCase):
 
     def test_make_key_unicode(self):
         translation.activate('en-US')
-        f = 'fragment\xe9\x9b\xbb\xe8\x85\xa6\xe7\x8e\xa6'
+        f = 'fragment\xe9\x9b\xbb\xe8\x85\xa6\xe7\x8e'
         # This would crash with a unicode error.
         base.make_key(f, with_locale=True)
         translation.deactivate()

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -7,6 +7,13 @@ import jinja2
 import mock
 from nose.tools import eq_
 
+# debugging Travis import failures
+import os
+import sys
+sys.stderr.write(str(os.environ['PYTHONPATH'].split(os.pathsep)) + '\n\n')
+from .testapp.models import Addon, User
+import caching
+
 from caching import base, invalidation
 from caching.compat import u
 

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -7,13 +7,6 @@ import jinja2
 import mock
 from nose.tools import eq_
 
-# debugging Travis import failures
-import os
-import sys
-sys.stderr.write(str(os.environ['PYTHONPATH'].split(os.pathsep)) + '\n\n')
-from .testapp.models import Addon, User
-import caching
-
 from caching import base, invalidation
 from caching.compat import u
 

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -346,13 +346,13 @@ class CachingTestCase(TestCase):
         eq_(base.cached_with([], f, 'key'), 1)
 
     def test_cached_with_unicode(self):
-        ustr = encoding.smart_bytes('\\u05ea\\u05d9\\u05d0\\u05d5\\u05e8 '
-                                    '\\u05d0\\u05d5\\u05e1\\u05e3')
+        u = encoding.smart_bytes('\\u05ea\\u05d9\\u05d0\\u05d5\\u05e8 '
+                                 '\\u05d0\\u05d5\\u05e1\\u05e3')
         obj = mock.Mock()
         obj.query_key.return_value = 'xxx'
         obj.flush_key.return_value = 'key'
         f = lambda: 1
-        eq_(base.cached_with(obj, f, 'adf:%s' % ustr), 1)
+        eq_(base.cached_with(obj, f, 'adf:%s' % u), 1)
 
     def test_cached_method(self):
         a = Addon.objects.get(id=1)

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -460,8 +460,8 @@ class CachingTestCase(TestCase):
         eq_([a.val for a in u.addon_set.all()], [42, 17])
 
     def test_make_key_unicode(self):
-        translation.activate(u('en-US'))
-        f = 'fragment\xe9\x9b\xbb\xe8\x85\xa6\xe7\x8e'
+        translation.activate('en-US')
+        f = 'fragment\xe9\x9b\xbb\xe8\x85\xa6\xe7\x8e\xa6'
         # This would crash with a unicode error.
         base.make_key(f, with_locale=True)
         translation.deactivate()

--- a/tests/testapp/models.py
+++ b/tests/testapp/models.py
@@ -1,3 +1,5 @@
+from __future__ import unicode_literals
+
 from django.db import models
 
 import mock

--- a/tests/testapp/models.py
+++ b/tests/testapp/models.py
@@ -1,8 +1,12 @@
 from __future__ import unicode_literals
 
 from django.db import models
+from django.utils import six
 
-import mock
+if six.PY3:
+    from unittest import mock
+else:
+    import mock
 
 from caching.base import CachingMixin, CachingManager, cached_method
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,21 @@
+# Tox (http://tox.testrun.org/) is a tool for running tests
+# in multiple virtualenvs. This configuration file will run the
+# test suite on all supported python versions. To use it, "pip install tox"
+# and then run "tox" from this directory.
+
+[tox]
+envlist =
+    py26-dj{14,15,16}
+    py27-dj{14,15,16,17,18}
+    py{33,34}-dj{15,16,17,18}
+
+[testenv]
+commands = {envpython} run_tests.py
+deps =
+    py{26,27}: -rrequirements/py2.txt
+    py{33,34}: -rrequirements/py3.txt
+    dj14: Django>=1.4,<1.5
+    dj15: Django>=1.5,<1.6
+    dj16: Django>=1.6,<1.7
+    dj17: Django>=1.7,<1.8
+    dj18: Django>=1.8,<1.9

--- a/tox.ini
+++ b/tox.ini
@@ -8,6 +8,8 @@ envlist =
     py26-dj{14,15,16}
     py27-dj{14,15,16,17,18}
     py{33,34}-dj{15,16,17,18}
+    py{27,34}-flake8
+    docs
 
 [testenv]
 commands = {envpython} run_tests.py
@@ -25,6 +27,9 @@ basepython = python2.7
 deps =
     Sphinx
     Django
+setenv =
+    PYTHONPATH = {toxinidir}/examples/
+    DJANGO_SETTINGS_MODULE = cache_machine.settings
 changedir = docs
 commands = /usr/bin/make html
 

--- a/tox.ini
+++ b/tox.ini
@@ -19,3 +19,21 @@ deps =
     dj16: Django>=1.6,<1.7
     dj17: Django>=1.7,<1.8
     dj18: Django>=1.8,<1.9
+
+[testenv:docs]
+basepython = python2.7
+deps =
+    Sphinx
+    Django
+changedir = docs
+commands = /usr/bin/make html
+
+[testenv:py27-flake8]
+basepython = python2.7
+deps = flake8
+commands = flake8
+
+[testenv:py34-flake8]
+basepython = python3.4
+deps = flake8
+commands = flake8


### PR DESCRIPTION
This PR adds support for Python 3.3 and 3.4 to cache-machine. A few notes:

* I ran ``2to3`` on this which may have added more ``list()``s than it needed to. I opted to leave them in just so ``2to3`` wouldn't report anything else to change.
* ``python-memcached`` doesn't support Python 3 yet, but there's a package ``python3-memcached`` that claims to. This (rather annoyingly) requires having separate requirements files for Python 2 and 3.
* I'm not entirely sure what ``test_make_key_unicode`` was testing, but I hope my change there doesn't break the test. The previous string was not valid unicode so there wasn't much of a way to do anything with it in Python 3.

I'm not entirely happy with all of the above so if there's a better way to do any of this (or anything else in the PR) I'm all ears.