### PR TITLE
Add support for invalidation after adding an object

### DIFF
--- a/caching/__init__.py
+++ b/caching/__init__.py
@@ -1,4 +1,4 @@
 from __future__ import unicode_literals
 
-VERSION = ('0', '9', '0', 'dev1')
+VERSION = ('0', '9')
 __version__ = '.'.join(VERSION)

--- a/caching/base.py
+++ b/caching/base.py
@@ -2,7 +2,6 @@ import functools
 import logging
 
 import django
-from django.conf import settings
 from django.db import models
 from django.db.models import signals
 from django.db.models.sql import query, EmptyResultSet
@@ -54,8 +53,8 @@ class CachingManager(models.Manager):
         # contain anything in the cache, but its corresponding flush key will.
         is_new_instance = kwargs.pop('is_new_instance', False)
         model_cls = kwargs.pop('model_cls', None)
-        if config.CACHE_INVALIDATE_ON_CREATE == config.WHOLE_MODEL and \
-          is_new_instance and model_cls and hasattr(model_cls, 'model_key'):
+        if (config.CACHE_INVALIDATE_ON_CREATE == config.WHOLE_MODEL and
+           is_new_instance and model_cls and hasattr(model_cls, 'model_key')):
             keys.append(model_cls.model_key())
         invalidator.invalidate_keys(keys)
 

--- a/caching/config.py
+++ b/caching/config.py
@@ -1,0 +1,18 @@
+from django.conf import settings
+
+NO_CACHE = -1
+WHOLE_MODEL = 'whole-model'
+
+CACHE_PREFIX = getattr(settings, 'CACHE_PREFIX', '')
+FETCH_BY_ID = getattr(settings, 'FETCH_BY_ID', False)
+FLUSH = CACHE_PREFIX + ':flush:'
+CACHE_EMPTY_QUERYSETS = getattr(settings, 'CACHE_EMPTY_QUERYSETS', False)
+TIMEOUT = getattr(settings, 'CACHE_COUNT_TIMEOUT', NO_CACHE)
+CACHE_INVALIDATE_ON_CREATE = getattr(settings, 'CACHE_INVALIDATE_ON_CREATE', None)
+CACHE_MACHINE_NO_INVALIDATION = getattr(settings, 'CACHE_MACHINE_NO_INVALIDATION', False)
+CACHE_MACHINE_USE_REDIS = getattr(settings, 'CACHE_MACHINE_USE_REDIS', False)
+
+_invalidate_on_create_values = (None, WHOLE_MODEL)
+if CACHE_INVALIDATE_ON_CREATE not in _invalidate_on_create_values:
+    raise ValueError('CACHE_INVALIDATE_ON_CREATE must be one of: '
+                     '%s' % _invalidate_on_create_values)

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -90,6 +90,19 @@ By default cache machine will not cache empty querysets. To cache them::
 
     CACHE_EMPTY_QUERYSETS = True
 
+Object creation
+^^^^^^^^^^^^^^^
+
+By default Cache Machine does not invalidate queries when a new object is
+created, because it can be expensive to maintain a flush list of all the
+queries associated with a given table and cause significant disruption on
+high-volume sites when *all* the queries for a particular model are
+invalidated at once. If these are not issues for your site and immediate
+inclusion of created objects in previously cached queries is desired, you
+can enable this feature as follows::
+
+    CACHE_INVALIDATE_ON_CREATE = 'whole-model'
+
 Cache Manager
 -------------
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -90,6 +90,8 @@ By default cache machine will not cache empty querysets. To cache them::
 
     CACHE_EMPTY_QUERYSETS = True
 
+.. _object-creation:
+
 Object creation
 ^^^^^^^^^^^^^^^
 

--- a/docs/releases.rst
+++ b/docs/releases.rst
@@ -3,10 +3,13 @@
 Release Notes
 ==================
 
-v0.9 (release date TBD)
------------------------
+v0.9 (2015-07-29)
+-----------------
 
 - Support for Python 3
+- A new setting, ``CACHE_INVALIDATE_ON_CREATE``, which facilitates invalidation
+  when a new model object is created. For more information, see
+  :ref:`object-creation`.
 
 v0.8.1 (2015-07-03)
 -----------------------

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -8,7 +8,7 @@ import jinja2
 import mock
 from nose.tools import eq_
 
-from caching import base, invalidation
+from caching import base, invalidation, config
 
 cache = invalidation.cache
 
@@ -38,12 +38,12 @@ class CachingTestCase(TestCase):
 
     def setUp(self):
         cache.clear()
-        self.old_timeout = base.TIMEOUT
+        self.old_timeout = config.TIMEOUT
         if getattr(settings, 'CACHE_MACHINE_USE_REDIS', False):
             invalidation.redis.flushall()
 
     def tearDown(self):
-        base.TIMEOUT = self.old_timeout
+        config.TIMEOUT = self.old_timeout
 
     def test_flush_key(self):
         """flush_key should work for objects or strings."""
@@ -166,7 +166,7 @@ class CachingTestCase(TestCase):
     def test_raw_nocache(self, CacheMachine):
         base.TIMEOUT = 60
         sql = 'SELECT * FROM %s WHERE id = 1' % Addon._meta.db_table
-        raw = list(Addon.objects.raw(sql, timeout=base.NO_CACHE))
+        raw = list(Addon.objects.raw(sql, timeout=config.NO_CACHE))
         eq_(len(raw), 1)
         raw_addon = raw[0]
         assert not hasattr(raw_addon, 'from_cache')
@@ -174,13 +174,14 @@ class CachingTestCase(TestCase):
 
     @mock.patch('caching.base.cache')
     def test_count_cache(self, cache_mock):
-        base.TIMEOUT = 60
+        config.TIMEOUT = 60
         cache_mock.scheme = 'memcached'
         cache_mock.get.return_value = None
 
         q = Addon.objects.all()
         q.count()
 
+        assert cache_mock.set.call_args, 'set not called'
         args, kwargs = cache_mock.set.call_args
         key, value, timeout = args
         eq_(value, 2)
@@ -188,7 +189,7 @@ class CachingTestCase(TestCase):
 
     @mock.patch('caching.base.cached')
     def test_count_none_timeout(self, cached_mock):
-        base.TIMEOUT = base.NO_CACHE
+        config.TIMEOUT = config.NO_CACHE
         Addon.objects.count()
         eq_(cached_mock.call_count, 0)
 
@@ -443,7 +444,7 @@ class CachingTestCase(TestCase):
             with self.assertNumQueries(k):
                 eq_(len(Addon.objects.filter(pk=42)), 0)
 
-    @mock.patch('caching.base.CACHE_EMPTY_QUERYSETS', True)
+    @mock.patch('caching.config.CACHE_EMPTY_QUERYSETS', True)
     def test_cache_empty_queryset(self):
         for k in (1, 0):
             with self.assertNumQueries(k):
@@ -455,7 +456,7 @@ class CachingTestCase(TestCase):
         Addon.objects.create(val=42, author1=u, author2=u)
         eq_([a.val for a in u.addon_set.all()], [42])
 
-    def test_invalidate_new_object(self):
+    def test_invalidate_new_related_object(self):
         u = User.objects.create()
         Addon.objects.create(val=42, author1=u, author2=u)
         eq_([a.val for a in u.addon_set.all()], [42])
@@ -501,3 +502,29 @@ class CachingTestCase(TestCase):
         host, params = parse_backend_uri(uri)
         self.assertEqual(host, '127.0.0.1:6379')
         self.assertEqual(params, {'socket_timeout': '5'})
+
+    @mock.patch('caching.config.CACHE_INVALIDATE_ON_CREATE', 'whole-model')
+    def test_invalidate_on_create_enabled(self):
+        """ Test that creating new objects invalidates cached queries for that model. """
+        eq_([a.name for a in User.objects.all()], ['fliggy', 'clouseroo'])
+        User.objects.create(name='spam')
+        users = User.objects.all()
+        # our new user should show up and the query should not have come from the cache
+        eq_([a.name for a in users], ['fliggy', 'clouseroo', 'spam'])
+        assert not any([u.from_cache for u in users])
+        # if we run it again, it should be cached this time
+        users = User.objects.all()
+        eq_([a.name for a in users], ['fliggy', 'clouseroo', 'spam'])
+        assert all([u.from_cache for u in User.objects.all()])
+
+    @mock.patch('caching.config.CACHE_INVALIDATE_ON_CREATE', None)
+    def test_invalidate_on_create_disabled(self):
+        """
+        Test that creating new objects does NOT invalidate cached queries when
+        whole-model invalidation on create is disabled.
+        """
+        users = User.objects.all()
+        assert users, "Can't run this test without some users"
+        assert not any([u.from_cache for u in users])
+        User.objects.create(name='spam')
+        assert all([u.from_cache for u in User.objects.all()])


### PR DESCRIPTION
This PR adds a simple workaround for invalidating *all* queries associated when a model when a new object is created. This can be expensive for high-volume sites, but might be desired for lower volume ones.

See issue #6 for full discussion.