### PR TITLE
fix infinite caching for pre-Django 1.6; leave cache methods as-is for Django 1.6 and later

### DIFF
--- a/caching/backends/memcached.py
+++ b/caching/backends/memcached.py
@@ -1,18 +1,27 @@
 from __future__ import unicode_literals
 
+import django
 from django.core.cache.backends import memcached
 
 from caching.compat import DEFAULT_TIMEOUT
 
 
-# Add infinite timeout support to the memcached backend.
+# Add infinite timeout support to the memcached backend, if needed.
 class InfinityMixin(object):
 
-    def add(self, key, value, timeout=DEFAULT_TIMEOUT, version=None):
-        return super(InfinityMixin, self).add(key, value, timeout, version)
+    if django.VERSION[:2] < (1, 6):
+        # Django 1.6 and later do it the right way already
+        def _get_memcache_timeout(self, timeout):
+            if timeout == 0:
+                return timeout
+            else:
+                return super(InfinityMixin, self)._get_memcache_timeout(timeout)
 
-    def set(self, key, value, timeout=DEFAULT_TIMEOUT, version=None):
-        return super(InfinityMixin, self).set(key, value, timeout, version)
+        def add(self, key, value, timeout=DEFAULT_TIMEOUT, version=None):
+            return super(InfinityMixin, self).add(key, value, timeout, version)
+
+        def set(self, key, value, timeout=DEFAULT_TIMEOUT, version=None):
+            return super(InfinityMixin, self).set(key, value, timeout, version)
 
 
 class MemcachedCache(InfinityMixin, memcached.MemcachedCache):

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -12,8 +12,9 @@ if six.PY3:
 else:
     import mock
 from nose.tools import eq_
+from nose.plugins.skip import SkipTest
 
-from caching import base, invalidation, config
+from caching import base, invalidation, config, compat
 from .testapp.models import Addon, User
 
 cache = invalidation.cache
@@ -403,6 +404,17 @@ class CachingTestCase(TestCase):
         a = q.get()
         assert hasattr(a, 'from_cache')
         eq_(a.id, 1)
+
+    @mock.patch('memcache.Client.set')
+    def test_infinite_timeout(self, mock_set):
+        """
+        Test that memcached infinite timeouts work with all Django versions.
+        """
+        if not any(['memcache' in c['BACKEND'] for c in settings.CACHES.values()]):
+            raise SkipTest('This test requires that Django use memcache')
+        cache.set('foo', 'bar', timeout=compat.FOREVER)
+        # for memcached, 0 timeout means store forever
+        mock_set.assert_called_with(':1:foo', 'bar', 0)
 
     def test_cache_and_no_cache(self):
         """Whatever happens last sticks."""


### PR DESCRIPTION
The documentation states that you can pass `FOREVER` to achieve infinite caching, however, this isn't true as the attached test demonstrates. Overriding `_get_memcache_timeout` to make sure `0` gets through to memcached fixes the issue.