### PR TITLE
fix failed invalidation across databases when using replication

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,7 @@ addons:
   postgresql: "9.4"
 before_script:
   - psql -c 'create database travis_ci_test;' -U postgres
+  - psql -c 'create database travis_ci_test2;' -U postgres
 install:
   - pip install -U pip  # make sure we have the latest version
   - pip install -e .

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,10 @@ python:
   - "2.7"
   - "3.3"
   - "3.4"
+addons:
+  postgresql: "9.4"
+before_script:
+  - psql -c 'create database travis_ci_test;' -U postgres
 install:
   - pip install -U pip  # make sure we have the latest version
   - pip install -e .

--- a/caching/base.py
+++ b/caching/base.py
@@ -49,16 +49,7 @@ class CachingManager(models.Manager):
 
     def invalidate(self, *objects, **kwargs):
         """Invalidate all the flush lists associated with ``objects``."""
-        keys = [k for o in objects for k in o._cache_keys()]
-        # If whole-model invalidation on create is enabled, include this model's
-        # key in the list to be invalidated. Note that the key itself won't
-        # contain anything in the cache, but its corresponding flush key will.
-        is_new_instance = kwargs.pop('is_new_instance', False)
-        model_cls = kwargs.pop('model_cls', None)
-        if (config.CACHE_INVALIDATE_ON_CREATE == config.WHOLE_MODEL and
-           is_new_instance and model_cls and hasattr(model_cls, 'model_key')):
-            keys.append(model_cls.model_key())
-        invalidator.invalidate_keys(keys)
+        invalidator.invalidate_objects(objects, **kwargs)
 
     def raw(self, raw_query, params=None, *args, **kwargs):
         return CachingRawQuerySet(raw_query, self.model, params=params,
@@ -107,7 +98,7 @@ class CacheMachine(object):
         # Try to fetch from the cache.
         cached = cache.get(query_key)
         if cached is not None:
-            log.debug('cache hit: %s' % self.query_string)
+            log.debug('cache hit: %s' % query_key)
             for obj in cached:
                 obj.from_cache = True
                 yield obj
@@ -125,13 +116,14 @@ class CacheMachine(object):
                 yield obj
         except StopIteration:
             if to_cache or config.CACHE_EMPTY_QUERYSETS:
-                self.cache_objects(to_cache)
+                self.cache_objects(to_cache, query_key)
             raise
 
-    def cache_objects(self, objects):
+    def cache_objects(self, objects, query_key):
         """Cache query_key => objects, then update the flush lists."""
-        query_key = self.query_key()
+        log.debug('query_key: %s' % query_key)
         query_flush = flush_key(self.query_string)
+        log.debug('query_flush: %s' % query_flush)
         cache.add(query_key, objects, timeout=self.timeout)
         invalidator.cache_objects(self.model, objects, query_key, query_flush)
 
@@ -259,38 +251,45 @@ class CachingMixin(object):
     def flush_key(self):
         return flush_key(self)
 
-    @property
-    def cache_key(self):
+    def get_cache_key(self, incl_db=True):
         """Return a cache key based on the object's primary key."""
-        return self._cache_key(self.pk, self._state.db)
+        return self._cache_key(self.pk, incl_db and self._state.db or None)
+    cache_key = property(get_cache_key)
 
     @classmethod
-    def model_key(cls):
+    def model_flush_key(cls):
         """
         Return a cache key for the entire model (used by invalidation).
         """
         # use dummy PK and DB reference that will never resolve to an actual
-        # cache key for an objection
-        return cls._cache_key('all-pks', 'all-dbs')
+        # cache key for an object
+        return flush_key(cls._cache_key('all-pks', 'all-dbs'))
 
     @classmethod
-    def _cache_key(cls, pk, db):
+    def _cache_key(cls, pk, db=None):
         """
         Return a string that uniquely identifies the object.
 
         For the Addon class, with a pk of 2, we get "o:addons.addon:2".
         """
-        key_parts = ('o', cls._meta, pk, db)
+        if db:
+            key_parts = ('o', cls._meta, pk, db)
+        else:
+            key_parts = ('o', cls._meta, pk)
         return ':'.join(map(encoding.smart_text, key_parts))
 
-    def _cache_keys(self):
+    def _cache_keys(self, incl_db=True):
         """Return the cache key for self plus all related foreign keys."""
         fks = dict((f, getattr(self, f.attname)) for f in self._meta.fields
                    if isinstance(f, models.ForeignKey))
-
-        keys = [fk.rel.to._cache_key(val, self._state.db) for fk, val in list(fks.items())
+        keys = [fk.rel.to._cache_key(val, incl_db and self._state.db or None)
+                for fk, val in list(fks.items())
                 if val is not None and hasattr(fk.rel.to, '_cache_key')]
-        return (self.cache_key,) + tuple(keys)
+        return (self.get_cache_key(incl_db=incl_db),) + tuple(keys)
+
+    def _flush_keys(self):
+        """Return the flush key for self plus all related foreign keys."""
+        return map(flush_key, self._cache_keys(incl_db=False))
 
 
 class CachingRawQuerySet(models.query.RawQuerySet):

--- a/caching/base.py
+++ b/caching/base.py
@@ -253,6 +253,9 @@ class CachingMixin(object):
 
     def get_cache_key(self, incl_db=True):
         """Return a cache key based on the object's primary key."""
+        # incl_db will be False if this key is intended for use in a flush key.
+        # This ensures all cached copies of an object will be invalidated
+        # regardless of the DB on which they're modified/deleted.
         return self._cache_key(self.pk, incl_db and self._state.db or None)
     cache_key = property(get_cache_key)
 

--- a/examples/cache_machine/settings.py
+++ b/examples/cache_machine/settings.py
@@ -1,3 +1,5 @@
+import os
+
 CACHES = {
     'default': {
         'BACKEND': 'caching.backends.memcached.MemcachedCache',
@@ -9,12 +11,13 @@ TEST_RUNNER = 'django_nose.runner.NoseTestSuiteRunner'
 
 DATABASES = {
     'default': {
-        'NAME': ':memory:',
-        'ENGINE': 'django.db.backends.sqlite3',
+        'NAME': os.environ.get('TRAVIS') and 'travis_ci_test' or 'cache_machine_devel',
+        'ENGINE': 'django.db.backends.postgresql_psycopg2',
     },
     'slave': {
-        'NAME': 'test_slave.db',
-        'ENGINE': 'django.db.backends.sqlite3',
+        'NAME': 'cache_machine_devel_slave',
+        'ENGINE': 'django.db.backends.postgresql_psycopg2',
+        'TEST_MIRROR': 'default',  # support older Django syntax for now
     },
 }
 

--- a/examples/cache_machine/settings.py
+++ b/examples/cache_machine/settings.py
@@ -15,9 +15,18 @@ DATABASES = {
         'ENGINE': 'django.db.backends.postgresql_psycopg2',
     },
     'slave': {
-        'NAME': 'cache_machine_devel_slave',
+        'NAME': 'cache_machine_devel',
         'ENGINE': 'django.db.backends.postgresql_psycopg2',
         'TEST_MIRROR': 'default',  # support older Django syntax for now
+    },
+    'master2': {
+        'NAME': os.environ.get('TRAVIS') and 'travis_ci_test2' or 'cache_machine_devel2',
+        'ENGINE': 'django.db.backends.postgresql_psycopg2',
+    },
+    'slave2': {
+        'NAME': 'cache_machine_devel2',
+        'ENGINE': 'django.db.backends.postgresql_psycopg2',
+        'TEST_MIRROR': 'master2',  # support older Django syntax for now
     },
 }
 

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -6,3 +6,4 @@ jinja2
 redis
 flake8
 coverage
+psycopg2

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -597,24 +597,3 @@ class MultiDbTestCase(TransactionTestCase):
         assert master_obj2.from_cache is True
         # ensure no crossover between databases
         assert master_obj.name != master_obj2.name
-
-    def test_multidb_sharding_no_invalidation(self):
-        """ Test for no invalidation when sharding w/distinct PKs"""
-        master_obj = User.objects.using('default').create(name='new-test-user')
-        # if pks are the same, objects *will* be invalidated across DBs
-        master_obj2 = User.objects.using('master2').create(pk=master_obj.pk+1,
-                                                           name='other-test-user')
-        # prime the cache for the default DB
-        master_obj = User.objects.using('default').get(name='new-test-user')
-        assert master_obj.from_cache is False
-        master_obj = User.objects.using('default').get(name='new-test-user')
-        assert master_obj.from_cache is True
-        # prime the cache for the 2nd master DB
-        master_obj2 = User.objects.using('master2').get(name='other-test-user')
-        assert master_obj2.from_cache is False
-        master_obj2 = User.objects.using('master2').get(name='other-test-user')
-        assert master_obj2.from_cache is True
-        # make sure master_obj2 query is not invalidated by a change to the 'default' db
-        master_obj.save()
-        master_obj2 = User.objects.using('master2').get(name='other-test-user')
-        assert master_obj2.from_cache is True

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -580,3 +580,40 @@ class MultiDbTestCase(TransactionTestCase):
         slave_obj = User.objects.using('slave').get(name='new-test-user')
         assert slave_obj.from_cache is False
         eq_(slave_obj.pk, master_obj.pk)
+
+    def test_multidb_no_db_crossover(self):
+        """ Test no crossover of objects with identical PKs """
+        master_obj = User.objects.using('default').create(name='new-test-user')
+        master_obj2 = User.objects.using('master2').create(pk=master_obj.pk, name='other-test-user')
+        # prime the cache for the default DB
+        master_obj = User.objects.using('default').get(name='new-test-user')
+        assert master_obj.from_cache is False
+        master_obj = User.objects.using('default').get(name='new-test-user')
+        assert master_obj.from_cache is True
+        # prime the cache for the 2nd master DB
+        master_obj2 = User.objects.using('master2').get(name='other-test-user')
+        assert master_obj2.from_cache is False
+        master_obj2 = User.objects.using('master2').get(name='other-test-user')
+        assert master_obj2.from_cache is True
+        # ensure no crossover between databases
+        assert master_obj.name != master_obj2.name
+
+    def test_multidb_sharding_no_invalidation(self):
+        """ Test for no invalidation when sharding w/distinct PKs"""
+        master_obj = User.objects.using('default').create(name='new-test-user')
+        # if pks are the same, objects *will* be invalidated across DBs
+        master_obj2 = User.objects.using('master2').create(pk=master_obj.pk+1, name='other-test-user')
+                # prime the cache for the default DB
+        master_obj = User.objects.using('default').get(name='new-test-user')
+        assert master_obj.from_cache is False
+        master_obj = User.objects.using('default').get(name='new-test-user')
+        assert master_obj.from_cache is True
+        # prime the cache for the 2nd master DB
+        master_obj2 = User.objects.using('master2').get(name='other-test-user')
+        assert master_obj2.from_cache is False
+        master_obj2 = User.objects.using('master2').get(name='other-test-user')
+        assert master_obj2.from_cache is True
+        # make sure master_obj2 query is not invalidated by a change to the 'default' db
+        master_obj.save()
+        master_obj2 = User.objects.using('master2').get(name='other-test-user')
+        assert master_obj2.from_cache is True

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -54,7 +54,7 @@ class CachingTestCase(TestCase):
     def test_flush_key(self):
         """flush_key should work for objects or strings."""
         a = Addon.objects.get(id=1)
-        eq_(base.flush_key(a.cache_key), base.flush_key(a))
+        eq_(base.flush_key(a.get_cache_key(incl_db=False)), base.flush_key(a))
 
     def test_cache_key(self):
         a = Addon.objects.get(id=1)
@@ -580,4 +580,3 @@ class MultiDbTestCase(TransactionTestCase):
         slave_obj = User.objects.using('slave').get(name='new-test-user')
         assert slave_obj.from_cache is False
         eq_(slave_obj.pk, master_obj.pk)
-        assert False

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -602,8 +602,9 @@ class MultiDbTestCase(TransactionTestCase):
         """ Test for no invalidation when sharding w/distinct PKs"""
         master_obj = User.objects.using('default').create(name='new-test-user')
         # if pks are the same, objects *will* be invalidated across DBs
-        master_obj2 = User.objects.using('master2').create(pk=master_obj.pk+1, name='other-test-user')
-                # prime the cache for the default DB
+        master_obj2 = User.objects.using('master2').create(pk=master_obj.pk+1,
+                                                           name='other-test-user')
+        # prime the cache for the default DB
         master_obj = User.objects.using('default').get(name='new-test-user')
         assert master_obj.from_cache is False
         master_obj = User.objects.using('default').get(name='new-test-user')

--- a/tests/testapp/models.py
+++ b/tests/testapp/models.py
@@ -28,6 +28,10 @@ class Addon(CachingMixin, models.Model):
 
     objects = CachingManager()
 
+    class Meta:
+        # without this, Postgres & SQLite return objects in different orders:
+        ordering = ('pk',)
+
     @cached_method
     def calls(self, arg=1):
         """This is a docstring for calls()"""


### PR DESCRIPTION
In 0.8, a regression was introduced (I believe by the changes in PR #29 or PR #36) that broke invalidation when an object previously cached from a slave database was later modified via the master database.

This test and change fixes that by removing the database from the flush key, thereby creating flush lists that are shared across databases. Objects are still cached per DB (so `obj._state.db` will be correct), but all cached objects/queries across DBs should be invalidated when one changes.

Getting this test working required a few changes to the way multi-DB tests are run, namely:
* use Django's `TEST_MIRROR` setting rather than simply duplicating the test data across DBs (without this, there's no way to remove an object from one DB without invalidating it on that DB)
* use `TransactionTestCase` (undocumented, but required by TEST_MIRROR setting)
* use Postgres (also undocumented, but `TEST_MIRROR` also does not appear to work with sqlite)