### PR TITLE
Improves unit tests by using `self.assertX` instead of raw `assert`s

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ install:
   - pip install coveralls
 script:
   - python run_tests.py --with-coverage
-  - flake8 .
+  - flake8 --ignore=E731,E402 .
 after_success:
   - coveralls
 env:

--- a/caching/invalidation.py
+++ b/caching/invalidation.py
@@ -226,7 +226,7 @@ def parse_backend_uri(backend_uri):
     host = rest
     qpos = rest.find('?')
     if qpos != -1:
-        params = dict(parse_qsl(rest[qpos+1:]))
+        params = dict(parse_qsl(rest[qpos + 1:]))
         host = rest[:qpos]
     else:
         params = {}

--- a/requirements/py2.txt
+++ b/requirements/py2.txt
@@ -1,3 +1,4 @@
 -r base.txt
 python-memcached
 mock==1.0.1
+unittest2

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -1,23 +1,29 @@
 from __future__ import unicode_literals
+import logging
+import pickle
+import sys
+
+if sys.version_info < (2, 7):
+    import unittest2 as unittest
+else:
+    import unittest
 
 import django
-import jinja2
-import pickle
-import logging
-
 from django.conf import settings
 from django.test import TestCase, TransactionTestCase
-from django.utils import translation, encoding, six
+from django.utils import translation, encoding
 
-if six.PY3:
+if sys.version_info >= (3, ):
     from unittest import mock
 else:
     import mock
-from nose.tools import eq_
-from nose.plugins.skip import SkipTest
+
+import jinja2
 
 from caching import base, invalidation, config, compat
+
 from .testapp.models import Addon, User
+
 
 cache = invalidation.cache
 log = logging.getLogger(__name__)
@@ -55,129 +61,129 @@ class CachingTestCase(TestCase):
     def test_flush_key(self):
         """flush_key should work for objects or strings."""
         a = Addon.objects.get(id=1)
-        eq_(base.flush_key(a.get_cache_key(incl_db=False)), base.flush_key(a))
+        self.assertEqual(base.flush_key(a.get_cache_key(incl_db=False)), base.flush_key(a))
 
     def test_cache_key(self):
         a = Addon.objects.get(id=1)
-        eq_(a.cache_key, 'o:testapp.addon:1:default')
+        self.assertEqual(a.cache_key, 'o:testapp.addon:1:default')
 
         keys = set((a.cache_key, a.author1.cache_key, a.author2.cache_key))
-        eq_(set(a._cache_keys()), keys)
+        self.assertEqual(set(a._cache_keys()), keys)
 
     def test_cache(self):
         """Basic cache test: second get comes from cache."""
-        assert Addon.objects.get(id=1).from_cache is False
-        assert Addon.objects.get(id=1).from_cache is True
+        self.assertIs(Addon.objects.get(id=1).from_cache, False)
+        self.assertIs(Addon.objects.get(id=1).from_cache, True)
 
     def test_filter_cache(self):
-        assert Addon.objects.filter(id=1)[0].from_cache is False
-        assert Addon.objects.filter(id=1)[0].from_cache is True
+        self.assertIs(Addon.objects.filter(id=1)[0].from_cache, False)
+        self.assertIs(Addon.objects.filter(id=1)[0].from_cache, True)
 
     def test_slice_cache(self):
-        assert Addon.objects.filter(id=1)[:1][0].from_cache is False
-        assert Addon.objects.filter(id=1)[:1][0].from_cache is True
+        self.assertIs(Addon.objects.filter(id=1)[:1][0].from_cache, False)
+        self.assertIs(Addon.objects.filter(id=1)[:1][0].from_cache, True)
 
     def test_invalidation(self):
-        assert Addon.objects.get(id=1).from_cache is False
+        self.assertIs(Addon.objects.get(id=1).from_cache, False)
         a = [x for x in Addon.objects.all() if x.id == 1][0]
-        assert a.from_cache is False
+        self.assertIs(a.from_cache, False)
 
-        assert Addon.objects.get(id=1).from_cache is True
+        self.assertIs(Addon.objects.get(id=1).from_cache, True)
         a = [x for x in Addon.objects.all() if x.id == 1][0]
-        assert a.from_cache is True
+        self.assertIs(a.from_cache, True)
 
         a.save()
-        assert Addon.objects.get(id=1).from_cache is False
+        self.assertIs(Addon.objects.get(id=1).from_cache, False)
         a = [x for x in Addon.objects.all() if x.id == 1][0]
-        assert a.from_cache is False
+        self.assertIs(a.from_cache, False)
 
-        assert Addon.objects.get(id=1).from_cache is True
+        self.assertIs(Addon.objects.get(id=1).from_cache, True)
         a = [x for x in Addon.objects.all() if x.id == 1][0]
-        assert a.from_cache is True
+        self.assertIs(a.from_cache, True)
 
     def test_invalidation_cross_locale(self):
-        assert Addon.objects.get(id=1).from_cache is False
+        self.assertIs(Addon.objects.get(id=1).from_cache, False)
         a = [x for x in Addon.objects.all() if x.id == 1][0]
-        assert a.from_cache is False
+        self.assertIs(a.from_cache, False)
 
-        assert Addon.objects.get(id=1).from_cache is True
+        self.assertIs(Addon.objects.get(id=1).from_cache, True)
         a = [x for x in Addon.objects.all() if x.id == 1][0]
-        assert a.from_cache is True
+        self.assertIs(a.from_cache, True)
 
         # Do query & invalidation in a different locale.
         old_locale = translation.get_language()
         translation.activate('fr')
-        assert Addon.objects.get(id=1).from_cache is True
+        self.assertIs(Addon.objects.get(id=1).from_cache, True)
         a = [x for x in Addon.objects.all() if x.id == 1][0]
-        assert a.from_cache is True
+        self.assertIs(a.from_cache, True)
 
         a.save()
 
         translation.activate(old_locale)
-        assert Addon.objects.get(id=1).from_cache is False
+        self.assertIs(Addon.objects.get(id=1).from_cache, False)
         a = [x for x in Addon.objects.all() if x.id == 1][0]
-        assert a.from_cache is False
+        self.assertIs(a.from_cache, False)
 
     def test_fk_invalidation(self):
         """When an object is invalidated, its foreign keys get invalidated."""
         a = Addon.objects.get(id=1)
-        assert User.objects.get(name='clouseroo').from_cache is False
+        self.assertIs(User.objects.get(name='clouseroo').from_cache, False)
         a.save()
 
-        assert User.objects.get(name='clouseroo').from_cache is False
+        self.assertIs(User.objects.get(name='clouseroo').from_cache, False)
 
     def test_fk_parent_invalidation(self):
         """When a foreign key changes, any parent objects get invalidated."""
-        assert Addon.objects.get(id=1).from_cache is False
+        self.assertIs(Addon.objects.get(id=1).from_cache, False)
         a = Addon.objects.get(id=1)
-        assert a.from_cache is True
+        self.assertIs(a.from_cache, True)
 
         u = User.objects.get(id=a.author1.id)
-        assert u.from_cache is True
+        self.assertIs(u.from_cache, True)
         u.name = 'fffuuu'
         u.save()
 
-        assert User.objects.get(id=a.author1.id).from_cache is False
+        self.assertIs(User.objects.get(id=a.author1.id).from_cache, False)
         a = Addon.objects.get(id=1)
-        assert a.from_cache is False
-        eq_(a.author1.name, 'fffuuu')
+        self.assertIs(a.from_cache, False)
+        self.assertEqual(a.author1.name, 'fffuuu')
 
     def test_raw_cache(self):
         sql = 'SELECT * FROM %s WHERE id = 1' % Addon._meta.db_table
         raw = list(Addon.objects.raw(sql))
-        eq_(len(raw), 1)
+        self.assertEqual(len(raw), 1)
         raw_addon = raw[0]
         a = Addon.objects.get(id=1)
         for field in Addon._meta.fields:
-            eq_(getattr(a, field.name), getattr(raw_addon, field.name))
-        assert raw_addon.from_cache is False
+            self.assertEqual(getattr(a, field.name), getattr(raw_addon, field.name))
+        self.assertIs(raw_addon.from_cache, False)
 
         cached = list(Addon.objects.raw(sql))
-        eq_(len(cached), 1)
+        self.assertEqual(len(cached), 1)
         cached_addon = cached[0]
         a = Addon.objects.get(id=1)
         for field in Addon._meta.fields:
-            eq_(getattr(a, field.name), getattr(cached_addon, field.name))
-        assert cached_addon.from_cache is True
+            self.assertEqual(getattr(a, field.name), getattr(cached_addon, field.name))
+        self.assertIs(cached_addon.from_cache, True)
 
     def test_raw_cache_params(self):
         """Make sure the query params are included in the cache key."""
         sql = 'SELECT * from %s WHERE id = %%s' % Addon._meta.db_table
         raw = list(Addon.objects.raw(sql, [1]))[0]
-        eq_(raw.id, 1)
+        self.assertEqual(raw.id, 1)
 
         raw2 = list(Addon.objects.raw(sql, [2]))[0]
-        eq_(raw2.id, 2)
+        self.assertEqual(raw2.id, 2)
 
     @mock.patch('caching.base.CacheMachine')
     def test_raw_nocache(self, CacheMachine):
         base.TIMEOUT = 60
         sql = 'SELECT * FROM %s WHERE id = 1' % Addon._meta.db_table
         raw = list(Addon.objects.raw(sql, timeout=config.NO_CACHE))
-        eq_(len(raw), 1)
+        self.assertEqual(len(raw), 1)
         raw_addon = raw[0]
-        assert not hasattr(raw_addon, 'from_cache')
-        assert not CacheMachine.called
+        self.assertFalse(hasattr(raw_addon, 'from_cache'))
+        self.assertFalse(CacheMachine.called)
 
     @mock.patch('caching.base.cache')
     def test_count_cache(self, cache_mock):
@@ -188,23 +194,23 @@ class CachingTestCase(TestCase):
         q = Addon.objects.all()
         q.count()
 
-        assert cache_mock.set.call_args, 'set not called'
+        self.assertTrue(cache_mock.set.call_args, 'set not called')
         args, kwargs = cache_mock.set.call_args
         key, value, timeout = args
-        eq_(value, 2)
-        eq_(timeout, 60)
+        self.assertEqual(value, 2)
+        self.assertEqual(timeout, 60)
 
     @mock.patch('caching.base.cached')
     def test_count_none_timeout(self, cached_mock):
         config.TIMEOUT = config.NO_CACHE
         Addon.objects.count()
-        eq_(cached_mock.call_count, 0)
+        self.assertEqual(cached_mock.call_count, 0)
 
     @mock.patch('caching.base.cached')
     def test_count_nocache(self, cached_mock):
         base.TIMEOUT = 60
         Addon.objects.no_cache().count()
-        eq_(cached_mock.call_count, 0)
+        self.assertEqual(cached_mock.call_count, 0)
 
     def test_queryset_flush_list(self):
         """Check that we're making a flush list for the queryset."""
@@ -214,8 +220,8 @@ class CachingTestCase(TestCase):
         cache.set('remove-me', 15)
 
         Addon.objects.invalidate(objects[0])
-        assert cache.get(q.flush_key()) is None
-        assert cache.get('remove-me') is None
+        self.assertIs(cache.get(q.flush_key()), None)
+        self.assertIs(cache.get('remove-me'), None)
 
     def test_jinja_cache_tag_queryset(self):
         env = jinja2.Environment(extensions=['caching.ext.cache'])
@@ -224,7 +230,7 @@ class CachingTestCase(TestCase):
             t = env.from_string(
                 "{% cache q %}{% for x in q %}{{ x.id }}:{{ x.val }};"
                 "{% endfor %}{% endcache %}")
-            eq_(t.render(q=q), expected)
+            self.assertEqual(t.render(q=q), expected)
 
         # Get the template in cache, then hijack iterator to make sure we're
         # hitting the cached fragment.
@@ -232,7 +238,7 @@ class CachingTestCase(TestCase):
         qs = Addon.objects.all()
         qs.iterator = mock.Mock()
         check(qs, '1:42;2:42;')
-        assert not qs.iterator.called
+        self.assertFalse(qs.iterator.called)
 
         # Make changes, make sure we dropped the cached fragment.
         a = Addon.objects.get(id=1)
@@ -241,7 +247,7 @@ class CachingTestCase(TestCase):
 
         q = Addon.objects.all()
         cache.get(q.flush_key())
-        assert cache.get(q.flush_key()) is None
+        self.assertIs(cache.get(q.flush_key()), None)
 
         check(Addon.objects.all(), '1:17;2:42;')
         qs = Addon.objects.all()
@@ -255,7 +261,7 @@ class CachingTestCase(TestCase):
         def check(obj, expected):
             t = env.from_string(
                 '{% cache obj, 30 %}{{ obj.id }}:{{ obj.val }}{% endcache %}')
-            eq_(t.render(obj=obj), expected)
+            self.assertEqual(t.render(obj=obj), expected)
 
         check(addon, '1:42')
         addon.val = 17
@@ -270,7 +276,7 @@ class CachingTestCase(TestCase):
 
         def check(obj, expected):
             t = env.from_string(template)
-            eq_(t.render(obj=obj), expected)
+            self.assertEqual(t.render(obj=obj), expected)
 
         check(addon, '1\n42')
         addon.val = 17
@@ -286,7 +292,7 @@ class CachingTestCase(TestCase):
 
         def check(obj, expected):
             t = env.from_string(template)
-            eq_(t.render(obj=obj), expected)
+            self.assertEqual(t.render(obj=obj), expected)
 
         addon.key = 1
         check(addon, '1:1')
@@ -311,33 +317,33 @@ class CachingTestCase(TestCase):
         f = lambda: base.cached_with(a, expensive, 'key')
 
         # Only gets called once.
-        eq_(f(), 1)
-        eq_(f(), 1)
+        self.assertEqual(f(), 1)
+        self.assertEqual(f(), 1)
 
         # Switching locales does not reuse the cache.
         old_locale = translation.get_language()
         translation.activate('fr')
-        eq_(f(), 2)
+        self.assertEqual(f(), 2)
 
         # Called again after flush.
         a.save()
-        eq_(f(), 3)
+        self.assertEqual(f(), 3)
 
         translation.activate(old_locale)
-        eq_(f(), 4)
+        self.assertEqual(f(), 4)
 
         counter.reset_mock()
         q = Addon.objects.filter(id=1)
         f = lambda: base.cached_with(q, expensive, 'key')
 
         # Only gets called once.
-        eq_(f(), 1)
-        eq_(f(), 1)
+        self.assertEqual(f(), 1)
+        self.assertEqual(f(), 1)
 
         # Called again after flush.
         list(q)[0].save()
-        eq_(f(), 2)
-        eq_(f(), 2)
+        self.assertEqual(f(), 2)
+        self.assertEqual(f(), 2)
 
     def test_cached_with_bad_object(self):
         """cached_with shouldn't fail if the object is missing a cache key."""
@@ -347,7 +353,7 @@ class CachingTestCase(TestCase):
             counter()
             return counter.call_count
 
-        eq_(base.cached_with([], f, 'key'), 1)
+        self.assertEqual(base.cached_with([], f, 'key'), 1)
 
     def test_cached_with_unicode(self):
         u = encoding.smart_bytes('\\u05ea\\u05d9\\u05d0\\u05d5\\u05e8 '
@@ -356,64 +362,63 @@ class CachingTestCase(TestCase):
         obj.query_key.return_value = 'xxx'
         obj.flush_key.return_value = 'key'
         f = lambda: 1
-        eq_(base.cached_with(obj, f, 'adf:%s' % u), 1)
+        self.assertEqual(base.cached_with(obj, f, 'adf:%s' % u), 1)
 
     def test_cached_method(self):
         a = Addon.objects.get(id=1)
-        eq_(a.calls(), (1, 1))
-        eq_(a.calls(), (1, 1))
+        self.assertEqual(a.calls(), (1, 1))
+        self.assertEqual(a.calls(), (1, 1))
 
         a.save()
         # Still returns 1 since the object has it's own local cache.
-        eq_(a.calls(), (1, 1))
-        eq_(a.calls(3), (3, 2))
+        self.assertEqual(a.calls(), (1, 1))
+        self.assertEqual(a.calls(3), (3, 2))
 
         a = Addon.objects.get(id=1)
-        eq_(a.calls(), (1, 3))
-        eq_(a.calls(4), (4, 4))
-        eq_(a.calls(3), (3, 2))
+        self.assertEqual(a.calls(), (1, 3))
+        self.assertEqual(a.calls(4), (4, 4))
+        self.assertEqual(a.calls(3), (3, 2))
 
         b = Addon.objects.create(id=5, val=32, author1_id=1, author2_id=2)
-        eq_(b.calls(), (1, 5))
+        self.assertEqual(b.calls(), (1, 5))
 
         # Make sure we're updating the wrapper's docstring.
-        eq_(b.calls.__doc__, Addon.calls.__doc__)
+        self.assertEqual(b.calls.__doc__, Addon.calls.__doc__)
 
     @mock.patch('caching.base.CacheMachine')
     def test_no_cache_from_manager(self, CacheMachine):
         a = Addon.objects.no_cache().get(id=1)
-        eq_(a.id, 1)
-        assert not hasattr(a, 'from_cache')
-        assert not CacheMachine.called
+        self.assertEqual(a.id, 1)
+        self.assertFalse(hasattr(a, 'from_cache'))
+        self.assertFalse(CacheMachine.called)
 
     @mock.patch('caching.base.CacheMachine')
     def test_no_cache_from_queryset(self, CacheMachine):
         a = Addon.objects.all().no_cache().get(id=1)
-        eq_(a.id, 1)
-        assert not hasattr(a, 'from_cache')
-        assert not CacheMachine.called
+        self.assertEqual(a.id, 1)
+        self.assertFalse(hasattr(a, 'from_cache'))
+        self.assertFalse(CacheMachine.called)
 
     def test_timeout_from_manager(self):
         q = Addon.objects.cache(12).filter(id=1)
-        eq_(q.timeout, 12)
+        self.assertEqual(q.timeout, 12)
         a = q.get()
-        assert hasattr(a, 'from_cache')
-        eq_(a.id, 1)
+        self.assertTrue(hasattr(a, 'from_cache'))
+        self.assertEqual(a.id, 1)
 
     def test_timeout_from_queryset(self):
         q = Addon.objects.all().cache(12).filter(id=1)
-        eq_(q.timeout, 12)
+        self.assertEqual(q.timeout, 12)
         a = q.get()
-        assert hasattr(a, 'from_cache')
-        eq_(a.id, 1)
+        self.assertTrue(hasattr(a, 'from_cache'))
+        self.assertEqual(a.id, 1)
 
+    @unittest.skipUnless(any(['memcache' in c['BACKEND'] for c in settings.CACHES.values()]), 'This test requires that Django use memcache')
     @mock.patch('memcache.Client.set')
     def test_infinite_timeout(self, mock_set):
         """
         Test that memcached infinite timeouts work with all Django versions.
         """
-        if not any(['memcache' in c['BACKEND'] for c in settings.CACHES.values()]):
-            raise SkipTest('This test requires that Django use memcache')
         cache.set('foo', 'bar', timeout=compat.FOREVER)
         # for memcached, 0 timeout means store forever
         mock_set.assert_called_with(':1:foo', 'bar', 0)
@@ -421,18 +426,18 @@ class CachingTestCase(TestCase):
     def test_cache_and_no_cache(self):
         """Whatever happens last sticks."""
         q = Addon.objects.no_cache().cache(12).filter(id=1)
-        eq_(q.timeout, 12)
+        self.assertEqual(q.timeout, 12)
 
         no_cache = q.no_cache()
 
         # The querysets don't share anything.
-        eq_(q.timeout, 12)
-        assert no_cache.timeout != 12
+        self.assertEqual(q.timeout, 12)
+        self.assertNotEqual(no_cache.timeout, 12)
 
-        assert not hasattr(no_cache.get(), 'from_cache')
+        self.assertFalse(hasattr(no_cache.get(), 'from_cache'))
 
-        eq_(q.get().id, 1)
-        assert hasattr(q.get(), 'from_cache')
+        self.assertEqual(q.get().id, 1)
+        self.assertTrue(hasattr(q.get(), 'from_cache'))
 
     @mock.patch('caching.base.cache')
     def test_cache_machine_timeout(self, cache):
@@ -441,46 +446,46 @@ class CachingTestCase(TestCase):
         cache.get_many.return_value = {}
 
         a = Addon.objects.cache(12).get(id=1)
-        eq_(a.id, 1)
+        self.assertEqual(a.id, 1)
 
-        assert cache.add.called
+        self.assertTrue(cache.add.called)
         args, kwargs = cache.add.call_args
-        eq_(kwargs, {'timeout': 12})
+        self.assertEqual(kwargs, {'timeout': 12})
 
     def test_unicode_key(self):
         list(User.objects.filter(name='\\xfcmla\\xfct'))
 
     def test_empty_in(self):
         # Raised an exception before fixing #2.
-        eq_([], list(User.objects.filter(pk__in=[])))
+        self.assertEqual([], list(User.objects.filter(pk__in=[])))
 
     def test_empty_in_count(self):
         # Regression test for #14.
-        eq_(0, User.objects.filter(pk__in=[]).count())
+        self.assertEqual(0, User.objects.filter(pk__in=[]).count())
 
     def test_empty_queryset(self):
         for k in (1, 1):
             with self.assertNumQueries(k):
-                eq_(len(Addon.objects.filter(pk=42)), 0)
+                self.assertEqual(len(Addon.objects.filter(pk=42)), 0)
 
     @mock.patch('caching.config.CACHE_EMPTY_QUERYSETS', True)
     def test_cache_empty_queryset(self):
         for k in (1, 0):
             with self.assertNumQueries(k):
-                eq_(len(Addon.objects.filter(pk=42)), 0)
+                self.assertEqual(len(Addon.objects.filter(pk=42)), 0)
 
     def test_invalidate_empty_queryset(self):
         u = User.objects.create()
-        eq_(list(u.addon_set.all()), [])
+        self.assertEqual(list(u.addon_set.all()), [])
         Addon.objects.create(val=42, author1=u, author2=u)
-        eq_([a.val for a in u.addon_set.all()], [42])
+        self.assertEqual([a.val for a in u.addon_set.all()], [42])
 
     def test_invalidate_new_related_object(self):
         u = User.objects.create()
         Addon.objects.create(val=42, author1=u, author2=u)
-        eq_([a.val for a in u.addon_set.all()], [42])
+        self.assertEqual([a.val for a in u.addon_set.all()], [42])
         Addon.objects.create(val=17, author1=u, author2=u)
-        eq_([a.val for a in u.addon_set.all()], [42, 17])
+        self.assertEqual([a.val for a in u.addon_set.all()], [42, 17])
 
     def test_make_key_unicode(self):
         translation.activate('en-US')
@@ -493,7 +498,7 @@ class CachingTestCase(TestCase):
     def test_get_flush_lists_none(self, cache_mock):
         if not getattr(settings, 'CACHE_MACHINE_USE_REDIS', False):
             cache_mock.return_value.values.return_value = [None, [1]]
-            eq_(base.invalidator.get_flush_lists(None), set([1]))
+            self.assertEqual(base.invalidator.get_flush_lists(None), set([1]))
 
     def test_parse_backend_uri(self):
         """ Test that parse_backend_uri works as intended. Regression for #92. """
@@ -506,16 +511,16 @@ class CachingTestCase(TestCase):
     @mock.patch('caching.config.CACHE_INVALIDATE_ON_CREATE', 'whole-model')
     def test_invalidate_on_create_enabled(self):
         """ Test that creating new objects invalidates cached queries for that model. """
-        eq_([a.name for a in User.objects.all()], ['fliggy', 'clouseroo'])
+        self.assertEqual([a.name for a in User.objects.all()], ['fliggy', 'clouseroo'])
         User.objects.create(name='spam')
         users = User.objects.all()
         # our new user should show up and the query should not have come from the cache
-        eq_([a.name for a in users], ['fliggy', 'clouseroo', 'spam'])
-        assert not any([u.from_cache for u in users])
+        self.assertEqual([a.name for a in users], ['fliggy', 'clouseroo', 'spam'])
+        self.assertFalse(any([u.from_cache for u in users]))
         # if we run it again, it should be cached this time
         users = User.objects.all()
-        eq_([a.name for a in users], ['fliggy', 'clouseroo', 'spam'])
-        assert all([u.from_cache for u in User.objects.all()])
+        self.assertEqual([a.name for a in users], ['fliggy', 'clouseroo', 'spam'])
+        self.assertTrue(all([u.from_cache for u in User.objects.all()]))
 
     @mock.patch('caching.config.CACHE_INVALIDATE_ON_CREATE', None)
     def test_invalidate_on_create_disabled(self):
@@ -524,10 +529,10 @@ class CachingTestCase(TestCase):
         whole-model invalidation on create is disabled.
         """
         users = User.objects.all()
-        assert users, "Can't run this test without some users"
-        assert not any([u.from_cache for u in users])
+        self.assertTrue(users, "Can't run this test without some users")
+        self.assertFalse(any([u.from_cache for u in users]))
         User.objects.create(name='spam')
-        assert all([u.from_cache for u in User.objects.all()])
+        self.assertTrue(all([u.from_cache for u in User.objects.all()]))
 
     def test_pickle_queryset(self):
         """
@@ -537,19 +542,19 @@ class CachingTestCase(TestCase):
         # pickled/unpickled on/from different Python processes which may have different
         # underlying values for DEFAULT_TIMEOUT:
         q1 = Addon.objects.all()
-        assert q1.timeout == compat.DEFAULT_TIMEOUT
+        self.assertEqual(q1.timeout, compat.DEFAULT_TIMEOUT)
         pickled = pickle.dumps(q1)
         new_timeout = object()
         with mock.patch('caching.base.DEFAULT_TIMEOUT', new_timeout):
             q2 = pickle.loads(pickled)
-            assert q2.timeout == new_timeout
+            self.assertEqual(q2.timeout, new_timeout)
         # Make sure values other than DEFAULT_TIMEOUT remain unaffected:
         q1 = Addon.objects.cache(10).all()
-        assert q1.timeout == 10
+        self.assertEqual(q1.timeout, 10)
         pickled = pickle.dumps(q1)
         with mock.patch('caching.base.DEFAULT_TIMEOUT', new_timeout):
             q2 = pickle.loads(pickled)
-            assert q2.timeout == 10
+            self.assertEqual(q2.timeout, 10)
 
 
 # use TransactionTestCase so that ['TEST']['MIRROR'] setting works
@@ -561,37 +566,37 @@ class MultiDbTestCase(TransactionTestCase):
 
     def test_multidb_cache(self):
         """ Test where master and slave DB result in two different cache keys """
-        assert Addon.objects.get(id=1).from_cache is False
-        assert Addon.objects.get(id=1).from_cache is True
+        self.assertIs(Addon.objects.get(id=1).from_cache, False)
+        self.assertIs(Addon.objects.get(id=1).from_cache, True)
 
         from_slave = Addon.objects.using('slave').get(id=1)
-        assert from_slave.from_cache is False
-        assert from_slave._state.db == 'slave'
+        self.assertIs(from_slave.from_cache, False)
+        self.assertEqual(from_slave._state.db, 'slave')
 
     def test_multidb_fetch_by_id(self):
         """ Test where master and slave DB result in two different cache keys with FETCH_BY_ID"""
         with self.settings(FETCH_BY_ID=True):
-            assert Addon.objects.get(id=1).from_cache is False
-            assert Addon.objects.get(id=1).from_cache is True
+            self.assertIs(Addon.objects.get(id=1).from_cache, False)
+            self.assertIs(Addon.objects.get(id=1).from_cache, True)
 
             from_slave = Addon.objects.using('slave').get(id=1)
-            assert from_slave.from_cache is False
-            assert from_slave._state.db == 'slave'
+            self.assertIs(from_slave.from_cache, False)
+            self.assertEqual(from_slave._state.db, 'slave')
 
     def test_multidb_master_slave_invalidation(self):
         """ Test saving an object on one DB invalidates it for all DBs """
         log.debug('priming the DB & cache')
         master_obj = User.objects.using('default').create(name='new-test-user')
         slave_obj = User.objects.using('slave').get(name='new-test-user')
-        assert slave_obj.from_cache is False
+        self.assertIs(slave_obj.from_cache, False)
         log.debug('deleting the original object')
         User.objects.using('default').filter(pk=slave_obj.pk).delete()
         log.debug('re-creating record with a new primary key')
         master_obj = User.objects.using('default').create(name='new-test-user')
         log.debug('attempting to force re-fetch from DB (should not use cache)')
         slave_obj = User.objects.using('slave').get(name='new-test-user')
-        assert slave_obj.from_cache is False
-        eq_(slave_obj.pk, master_obj.pk)
+        self.assertIs(slave_obj.from_cache, False)
+        self.assertEqual(slave_obj.pk, master_obj.pk)
 
     def test_multidb_no_db_crossover(self):
         """ Test no crossover of objects with identical PKs """
@@ -599,13 +604,13 @@ class MultiDbTestCase(TransactionTestCase):
         master_obj2 = User.objects.using('master2').create(pk=master_obj.pk, name='other-test-user')
         # prime the cache for the default DB
         master_obj = User.objects.using('default').get(name='new-test-user')
-        assert master_obj.from_cache is False
+        self.assertIs(master_obj.from_cache, False)
         master_obj = User.objects.using('default').get(name='new-test-user')
-        assert master_obj.from_cache is True
+        self.assertIs(master_obj.from_cache, True)
         # prime the cache for the 2nd master DB
         master_obj2 = User.objects.using('master2').get(name='other-test-user')
-        assert master_obj2.from_cache is False
+        self.assertIs(master_obj2.from_cache, False)
         master_obj2 = User.objects.using('master2').get(name='other-test-user')
-        assert master_obj2.from_cache is True
+        self.assertIs(master_obj2.from_cache, True)
         # ensure no crossover between databases
-        assert master_obj.name != master_obj2.name
+        self.assertNotEqual(master_obj.name, master_obj2.name)

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -414,8 +414,8 @@ class CachingTestCase(TestCase):
         self.assertEqual(a.id, 1)
 
     @unittest.skipUnless(
-            any(['memcache' in c['BACKEND'] for c in settings.CACHES.values()]),
-            'This test requires that Django use memcache')
+        any(['memcache' in c['BACKEND'] for c in settings.CACHES.values()]),
+        'This test requires that Django use memcache')
     @mock.patch('memcache.Client.set')
     def test_infinite_timeout(self, mock_set):
         """

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -413,7 +413,9 @@ class CachingTestCase(TestCase):
         self.assertTrue(hasattr(a, 'from_cache'))
         self.assertEqual(a.id, 1)
 
-    @unittest.skipUnless(any(['memcache' in c['BACKEND'] for c in settings.CACHES.values()]), 'This test requires that Django use memcache')
+    @unittest.skipUnless(
+            any(['memcache' in c['BACKEND'] for c in settings.CACHES.values()]),
+            'This test requires that Django use memcache')
     @mock.patch('memcache.Client.set')
     def test_infinite_timeout(self, mock_set):
         """


### PR DESCRIPTION
The use of raw `assert`s in unit testing is a bit of an anti-pattern as `assert`s can be disabled at runtime via `python -O`.

This PR converts all of these raw `assert` calls, as well as the use of the `eq_` helper function from `nose` to native `self.assertX` calls provided by the `unittest` library. Added a fallback to `unittest2` for Python 2.6.

Note: the travis tests are failing because of an unpinned version install on `flake8`. If you bump travis to rerun `master`, it will fail for the same reason due to additional checks introduced in `flake8` since travis was last run on `master`.