### PR TITLE
Improve flush-list search by avoiding skipping too many cache-keys.

### DIFF
--- a/caching/invalidation.py
+++ b/caching/invalidation.py
@@ -141,7 +141,7 @@ class Invalidator(object):
         while 1:
             new_keys = set()
             for key in self.get_flush_lists(search_keys):
-                if key.startswith(config.FLUSH):
+                if key.startswith(config.FLUSH) and key not in flush_keys:
                     new_keys.add(key)
                 else:
                     obj_keys.add(key)


### PR DESCRIPTION
As we're using `new_keys` to build up `flush_keys` and `search_keys`
we still might need the proper keys in `obj_keys` to avoid objects
not being invalidated properly.

There are some tests missing currently unfortunately but even without the patch the test-suite is failing for me locally so it's quite hard to reason about any particular changes. This should be straight forward enough though.

Let me know what you think :)
