### PR TITLE
Updated six imports for Django3

### DIFF
--- a/caching/invalidation.py
+++ b/caching/invalidation.py
@@ -6,12 +6,14 @@ import hashlib
 import logging
 import socket
 
+import six
+from six.moves.urllib.parse import parse_qsl
+
 from django.conf import settings
 from django.core.cache import cache as default_cache
 from django.core.cache import caches
 from django.core.cache.backends.base import InvalidCacheBackendError
-from django.utils import encoding, six, translation
-from django.utils.six.moves.urllib.parse import parse_qsl
+from django.utils import encoding, translation
 
 from caching import config
 

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -8,3 +8,4 @@ flake8
 coverage
 psycopg2
 python-memcached>=1.58
+six

--- a/tests/testapp/models.py
+++ b/tests/testapp/models.py
@@ -1,8 +1,8 @@
 from __future__ import unicode_literals
 
+import six
 import django
 from django.db import models
-from django.utils import six
 from caching.base import CachingMixin, CachingManager, cached_method
 
 if six.PY3:


### PR DESCRIPTION
`six` was removed from `django.utils` in v3: https://docs.djangoproject.com/en/3.0/releases/3.0/#removed-private-python-2-compatibility-apis

> django.utils.six - Remove usage of this vendored library or switch to six.

Switch to directly import `six`