### PR TITLE
docs: fix simple typo, condtions -> conditions

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -105,7 +105,7 @@ cleared.  To avoid stale foreign key relations, any cached objects will be
 flushed when the object their foreign key points to is invalidated.
 
 During cache invalidation, we explicitly set a None value instead of just
-deleting so we don't have any race condtions where:
+deleting so we don't have any race conditions where:
 
  * Thread 1 -> Cache miss, get object from DB
  * Thread 2 -> Object saved, deleted from cache


### PR DESCRIPTION
There is a small typo in docs/index.rst.

Should read `conditions` rather than `condtions`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md